### PR TITLE
nacl_helper_bootstrap: associate .rodata with :text PHDR, fix build with GCC

### DIFF
--- a/src/trusted/service_runtime/linux/nacl_bootstrap.x
+++ b/src/trusted/service_runtime/linux/nacl_bootstrap.x
@@ -78,7 +78,7 @@ SECTIONS {
   .rodata : {
     *(.rodata*)
     *(.eh_frame*)
-  }
+  } :text
 
   etext = .;
 


### PR DESCRIPTION
Extracted from:

- https://github.com/DaemonEngine/native_client/pull/2

Disclosure: this 6-characters fix is the result of me toying with ChatGPT as I used that bug for an experiment:

```diff
--- a/src/trusted/service_runtime/linux/nacl_bootstrap.x
+++ b/src/trusted/service_runtime/linux/nacl_bootstrap.x
@@ -78,7 +78,7 @@ SECTIONS {
   .rodata : {
     *(.rodata*)
     *(.eh_frame*)
-  }
+  } :text
 
   etext = .;
 
```

The bug as I experienced it 8 months ago was that the `nacl_helper_bootstrap` was segfaulting when built with GCC, not when built with Clang. At the time I identified the bug I could build it with GCC up to GCC 12 in an old Debian chroot. On a more recent Ubuntu today, I could not build the bootstrap helper with any GCC version, including some as old as GCC 9.

So out of curiosity I did some experiments with ChatGPT, submitting the results of my existing discoveries done in my previous debugging sessions, the description of how I built the tool and some dump of built executable metadata, and even an hexdump of the bogus binary itself. I kept secret the fact the old GCCs that were building properly the binary were running on an older system with older binaries in `PATH`.

ChatGPT suggested this fix, explaining that supposedly a `ld.bfd` change happened in binutils modifying the behavior, the explanation proposed was that the `.rodata` section isn't assigned to any PHDR because the `.rodata` layout has no PHDR tag, so with older binutils the `.rodata` was implicitly attached to the previous PHDR, but that with newer binutils it wasn't, so the `_start` entry point would jump to unmapped memory and crash. This explanation is consistent with my observation where I noticed in debugger that it was crashing early on `_start`. The suggestion of a behavioral change due to a different environment (which I had not disclosed) and not in GCC is also consistent with my observation.

It is suggested that the fact the code runs when built with Clang is fortuitous.

I verified that with this small change the bootstrap helper not only builds with GCC but also runs properly.