### PR TITLE
Discard extra sections linking nacl_helper_bootstrap

### DIFF
--- a/src/trusted/service_runtime/build.scons
+++ b/src/trusted/service_runtime/build.scons
@@ -428,6 +428,7 @@ if (env.Bit('linux') and not env.Bit('built_elsewhere')):
       [bootstrap_obj],
       ("env CXX='${CXX}' ${PYTHON} %s %s " +
        '-m %s --build-id -static -z max-page-size=0x1000 ' +
+       '--orphan-handling=discard ' +
        '--defsym RESERVE_TOP=%s --script %s -o ${TARGET} ${SOURCES}') %
       (bootstrap_env.File('linux/ld_bfd.py'), compiler_override, ld_emul,
        reserve_top, bootstrap_env.File('linux/nacl_bootstrap.x')),

--- a/src/trusted/service_runtime/linux/nacl_bootstrap.x
+++ b/src/trusted/service_runtime/linux/nacl_bootstrap.x
@@ -5,8 +5,9 @@
  *
  * This is a custom linker script used to build nacl_helper_bootstrap.
  * It has a very special layout.  This script will only work with input
- * that is kept extremely minimal.  If there are unexpected input sections
- * not named here, the result will not be correct.
+ * that is kept extremely minimal.  Unexpected input sections will be
+ * discarded so if there are unexpected input sections not named here which
+ * are actually important, the result will not be correct.
  *
  * We need to use a standalone loader program rather than just using a
  * dynamically-linked program here because its entire address space will be


### PR DESCRIPTION
One way of working around the linker bug from #6. Also makes the binary smaller