### PR TITLE
Allow building with Clang without installing GCC

### DIFF
--- a/src/trusted/service_runtime/build.scons
+++ b/src/trusted/service_runtime/build.scons
@@ -417,7 +417,7 @@ if (env.Bit('linux') and not env.Bit('built_elsewhere')):
   elif env.Bit('build_arm'):
     ld_emul = 'armelf_linux_eabi'
     reserve_top = '0x40002000'
-    compiler_override = '--compiler arm-linux-gnueabihf-gcc'
+    compiler_override = '--compiler arm-linux-gnueabihf-g++'
   elif env.Bit('build_mips32'):
     ld_emul = 'elf32ltsmip'
     reserve_top = '0x40008000'

--- a/src/trusted/service_runtime/linux/ld_bfd.py
+++ b/src/trusted/service_runtime/linux/ld_bfd.py
@@ -69,10 +69,15 @@ def main(args):
   else:
     cxx_bin = os.getenv('CXX', 'g++')
 
-  args = [FindLDBFD(cxx_bin)] + args
-  libgcc = FindLibgcc(cxx_bin)
-  if libgcc is not None:
-    args.append(libgcc)
+  if 0:
+    args = [FindLDBFD(cxx_bin)] + args
+    libgcc = FindLibgcc(cxx_bin)
+    if libgcc is not None:
+      args.append(libgcc)
+  else:
+    assert cxx_bin.endswith("g++")
+    ld = cxx_bin[:-3] + "ld.bfd"
+    args = [ld] + args
   return subprocess.call(args)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stop using GCC `-print-prog-name` to locate the linker. So you only have to install GNU binutils to build with clang, not GCC.