### PR TITLE
Add CMake install target

### DIFF
--- a/src/trusted/service_runtime/CMakeLists.txt
+++ b/src/trusted/service_runtime/CMakeLists.txt
@@ -374,6 +374,7 @@ if (NOT COVERAGE_ENABLED OR NOT YOKAI_TARGET_SYSTEM_WINDOWS)
 
 	add_executable(sel_ldr)
 	target_link_libraries(sel_ldr ${LDR_LIBS})
+	install(TARGETS sel_ldr DESTINATION bin)
 
 	if (YOKAI_TARGET_SYSTEM_MACOS)
 		# This target exists only to check that the service_runtime code

--- a/src/trusted/service_runtime/linux/CMakeLists.txt
+++ b/src/trusted/service_runtime/linux/CMakeLists.txt
@@ -129,3 +129,8 @@ add_custom_target(nacl_helper_bootstrap ALL
 	DEPENDS nacl_bootstrap_raw
 	BYPRODUCTS "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/nacl_helper_bootstrap"
 )
+
+install(PROGRAMS
+	"${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/nacl_helper_bootstrap"
+	DESTINATION bin
+)


### PR DESCRIPTION
Add `instal`l target.

The `install` target is needed for integration in `external_deps/build.sh`.

Requires:

- https://github.com/DaemonEngine/native_client/pull/14