### PR TITLE
Fix incompatible pointer type in Windows code (nacl_host_dir.c)

### DIFF
--- a/src/shared/platform/win/nacl_host_dir.c
+++ b/src/shared/platform/win/nacl_host_dir.c
@@ -40,7 +40,7 @@
 static int NaClHostDirInit(struct NaClHostDir *d) {
   int retval;
 
-  d->handle = FindFirstFile(d->pattern, &d->find_data);
+  d->handle = FindFirstFileW(d->pattern, &d->find_data);
   d->off = 0;
   d->done = 0;
 
@@ -217,7 +217,7 @@ ssize_t NaClHostDirGetdents(struct NaClHostDir  *d,
     i += nacl_abi_rec_length;
     ++d->off;
 
-    if (!FindNextFile(d->handle, &d->find_data)) {
+    if (!FindNextFileW(d->handle, &d->find_data)) {
       int win_err = GetLastError();
       if (win_err == ERROR_NO_MORE_FILES) {
         d->done = 1;


### PR DESCRIPTION
Fixes:

```
src/shared/platform/win/nacl_host_dir.c:43:30: error: passing argument 1 of 'FindFirstFileA' from incompatible pointer type [-Wincompatible-pointer-types]
   43 |   d->handle = FindFirstFile(d->pattern, &d->find_data);
      |                             ~^~~~~~~~~
      |                              |
      |                              wchar_t * {aka short unsigned int *}

src/shared/platform/win/nacl_host_dir.c:220:34: error: passing argument 2 of 'FindNextFileA' from incompatible pointer type [-Wincompatible-pointer-types]
  220 |     if (!FindNextFile(d->handle, &d->find_data)) {
      |                                  ^~~~~~~~~~~~~
      |                                  |
      |                                  WIN32_FIND_DATAW *
```

I reproduced it with MinGW from Debian 13.2 Trixie.
I didn't reproduced it with MinGW from Ubuntu 24.04.4 Noble.

I noticed it while working on implementing the NaCl loader build in Dæmon's external deps:

- https://github.com/DaemonEngine/Daemon/pull/1986