### PR TITLE
Fix incompatible pointer type in Windows code (nacl_host_desc.c)

### DIFF
--- a/src/shared/platform/nacl_host_desc.h
+++ b/src/shared/platform/nacl_host_desc.h
@@ -62,7 +62,7 @@ typedef struct stat nacl_host_stat_t;
 # define NACL_HOST_STAT64 stat
 # define NACL_HOST_LSTAT64 lstat
 #elif NACL_WINDOWS
-typedef struct _stati64 nacl_host_stat_t;
+typedef struct _stat64 nacl_host_stat_t;
 # define NACL_HOST_FSTAT64 _fstat64
 # define NACL_HOST_STAT64 _stati64
 #elif defined __native_client__

--- a/src/shared/platform/nacl_host_desc.h
+++ b/src/shared/platform/nacl_host_desc.h
@@ -64,7 +64,7 @@ typedef struct stat nacl_host_stat_t;
 #elif NACL_WINDOWS
 typedef struct _stat64 nacl_host_stat_t;
 # define NACL_HOST_FSTAT64 _fstat64
-# define NACL_HOST_STAT64 _stati64
+# define NACL_HOST_STAT64 _stat64
 #elif defined __native_client__
 /* nacl_host_stat_t not exposed to NaCl module code */
 #else


### PR DESCRIPTION
Yet again, spotted with MinGW from Trixie, this time with an i686 build:

```
src/shared/platform/win/nacl_host_desc.c: In function 'NaClHostDescCtorIntern':
src/shared/platform/win/nacl_host_desc.c:909:25: error: passing argument 2 of '_fstat64' from incompatible pointer type [-Wincompatible-pointer-types]
  909 |   if (_fstat64(posix_d, &stbuf) != 0) {
      |                         ^~~~~~
      |                         |
      |                         nacl_host_stat_t * {aka struct _stati64 *}
In file included from include-hax/native_client/src/shared/platform/nacl_host_desc.h:15,
                 from src/shared/platform/win/nacl_host_desc.c:27:
/usr/share/mingw-w64/include/sys/stat.h:71:61: note: expected 'struct _stat64 *' but argument is of type 'nacl_host_stat_t *' {aka 'struct _stati64 *'}
   71 |   _CRTIMP int __cdecl _fstat64(int _FileDes,struct _stat64 *_Stat);
      |                                             ~~~~~~~~~~~~~~~~^~~~~
src/shared/platform/win/nacl_host_desc.c: In function 'NaClHostDescFstat':
src/shared/platform/win/nacl_host_desc.c:1369:31: error: passing argument 2 of '_fstat64' from incompatible pointer type [-Wincompatible-pointer-types]
 1369 |   if (NACL_HOST_FSTAT64(d->d, nasp) == -1) {
      |                               ^~~~
      |                               |
      |                               nacl_host_stat_t * {aka struct _stati64 *}
/usr/share/mingw-w64/include/sys/stat.h:71:61: note: expected 'struct _stat64 *' but argument is of type 'nacl_host_stat_t *' {aka 'struct _stati64 *'}
   71 |   _CRTIMP int __cdecl _fstat64(int _FileDes,struct _stat64 *_Stat);
```

```

src/shared/platform/win/nacl_host_desc.c: In function 'NaClHostDescStat':
src/shared/platform/win/nacl_host_desc.c:1405:30: error: passing argument 2 of '_stati64' from incompatible pointer type [-Wincompatible-pointer-types]
 1405 |   if (NACL_HOST_STAT64(path, nhsp) == -1) {
      |                              ^~~~
      |                              |
      |                              nacl_host_stat_t * {aka struct _stat64 *}
```