### PR TITLE
Fix building with Clang on x86(-64)

### DIFF
--- a/src/trusted/service_runtime/linux/ld_bfd.py
+++ b/src/trusted/service_runtime/linux/ld_bfd.py
@@ -14,6 +14,7 @@ via the -B flag.
 from __future__ import print_function
 
 import os
+import re
 import subprocess
 import sys
 
@@ -74,10 +75,12 @@ def main(args):
     libgcc = FindLibgcc(cxx_bin)
     if libgcc is not None:
       args.append(libgcc)
-  else:
-    assert cxx_bin.endswith("g++")
+  elif re.search('[^a-zA-Z]g[+][+]$', cxx_bin):
     ld = cxx_bin[:-3] + "ld.bfd"
     args = [ld] + args
+  else:
+    # We just have to hope the system binutils knows about the target platform
+    args = ["ld.bfd"] + args
   return subprocess.call(args)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix regression in b0e5b98072bd60d07f8d1553853e62cb0092ece9 which assumed the compiler passed to ld_bfd.py is always a GCC. In fact, in this case Clang's path is passed in. "clang++" happens to match the expected "g++" pattern, but that didn't really help us!