### PR TITLE
Restore ld_bfd finding libgcc to link with it, fix bootstrap build for linux-armhf

### DIFF
--- a/src/trusted/service_runtime/linux/ld_bfd.py
+++ b/src/trusted/service_runtime/linux/ld_bfd.py
@@ -70,17 +70,18 @@ def main(args):
   else:
     cxx_bin = os.getenv('CXX', 'g++')
 
-  if 0:
-    args = [FindLDBFD(cxx_bin)] + args
-    libgcc = FindLibgcc(cxx_bin)
-    if libgcc is not None:
-      args.append(libgcc)
-  elif re.search('[^a-zA-Z]g[+][+]$', cxx_bin):
+  # Match g++, <target>-g++, but not clang++.
+  if re.search('[^a-zA-Z]g[+][+]$', cxx_bin):
     ld = cxx_bin[:-3] + "ld.bfd"
     args = [ld] + args
   else:
     # We just have to hope the system binutils knows about the target platform
     args = ["ld.bfd"] + args
+
+  libgcc = FindLibgcc(cxx_bin)
+  if libgcc is not None:
+    args.append(libgcc)
+
   return subprocess.call(args)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Restore `ld_bfd` finding `libgcc` to link with it, fix bootstrap build for `linux-armhf`.

Fixup for:

- https://github.com/DaemonEngine/native_client/pull/26

Fixes:

```
arm-linux-gnueabihf-ld.bfd: nacl_bootstrap.dir/nacl_bootstrap.c.o: in function `iov_int_string':
nacl_bootstrap.c:118: undefined reference to `__aeabi_idivmod'
```