### PR TITLE
Fix nacl_bootstrap_prereservation_test on ARM

### DIFF
--- a/src/trusted/service_runtime/build.scons
+++ b/src/trusted/service_runtime/build.scons
@@ -558,10 +558,7 @@ if env.Bit('linux'):
       'nacl_bootstrap_prereservation_test.out',
       command=env.AddBootstrap(nacl_bootstrap_prereservation_test_exe, []))
   env.AddNodeToTestSuite(node, ['small_tests'],
-                         'run_nacl_bootstrap_prereservation_test',
-                         # TODO(crbug.com/1101347): This fails on ARM bots.
-                         is_broken=env.Bit('build_arm')
-                             and not env.UsingEmulator())
+                         'run_nacl_bootstrap_prereservation_test')
 
 
 # also seems to have issues with windows coverage or VMs

--- a/src/trusted/service_runtime/linux/nacl_bootstrap_prereservation_test.c
+++ b/src/trusted/service_runtime/linux/nacl_bootstrap_prereservation_test.c
@@ -56,6 +56,14 @@ void FindLowestMappedRange(uintptr_t *start, uintptr_t *end) {
   fclose(fp);
 }
 
+// See FIRST_USER_ADDRESS in kernel. It is supposed to impossible to reserve pages
+// lower than this (though sometimes you can due to bugs...) and causes EINVAL.
+#if NACL_ARCH(NACL_BUILD_ARCH) == NACL_arm
+#  define MIN_VALID_ADDRESS (2u * NACL_PAGESIZE)
+#else
+#  define MIN_VALID_ADDRESS 0u
+#endif
+
 int IsPageMappable(uintptr_t addr) {
   void *retval = mmap((void *) addr, NACL_PAGESIZE, PROT_NONE,
                       MAP_PRIVATE | MAP_FIXED |
@@ -64,7 +72,7 @@ int IsPageMappable(uintptr_t addr) {
   if (retval != (void *) addr)   {
     CHECK(MAP_FAILED == retval &&
           (EPERM == errno || EACCES == errno ||
-           (EINVAL == errno && 0 == addr)));
+           (EINVAL == errno && addr < MIN_VALID_ADDRESS)));
     return 0;
   }
   return 1;


### PR DESCRIPTION
Linux commit d8aa712c30148ba26fd89a5dc14de95d4c375184 changed FIRST_USER_ADDRESS to prevent mapping 2 pages instead of 1.