### PR TITLE
Disable DEP qualifications outside of MSVC

### DIFF
--- a/src/trusted/platform_qualify/win/nacl_dep_qualify.c
+++ b/src/trusted/platform_qualify/win/nacl_dep_qualify.c
@@ -19,6 +19,7 @@
 
 
 int NaClAttemptToExecuteDataAtAddr(uint8_t *thunk_buffer, size_t size) {
+#if defined(_MSC_VER)
   int got_fault = 0;
   nacl_void_thunk thunk = NaClGenerateThunk(thunk_buffer, size);
   __try {
@@ -28,12 +29,16 @@ int NaClAttemptToExecuteDataAtAddr(uint8_t *thunk_buffer, size_t size) {
     got_fault = 1;
   }
   return got_fault;
+#else
+  return 1;
+#endif
 }
 
 /*
  * Returns 1 if Data Execution Prevention is present and working.
  */
 int NaClAttemptToExecuteData(void) {
+#if defined(_MSC_VER)
   int result;
   uint8_t *thunk_buffer = malloc(64);
   if (NULL == thunk_buffer) {
@@ -42,4 +47,7 @@ int NaClAttemptToExecuteData(void) {
   result = NaClAttemptToExecuteDataAtAddr(thunk_buffer, 64);
   free(thunk_buffer);
   return result;
+#else
+  return 1;
+#endif
 }


### PR DESCRIPTION
- win32: disable DEP qualifications outside of MSVC

Fixup for:

- https://github.com/DaemonEngine/native_client/pull/34

This broke MinGW Windows build:

```
src/trusted/platform_qualify/win/nacl_dep_qualify.c:24:3: error:
 '__try' undeclared (first use in this function)
   24 |   __try {
      |   ^~~~~
src/trusted/platform_qualify/win/nacl_dep_qualify.c:24:8:
 error: expected ';' before '{' token
   24 |   __try {
      |        ^~
      |        ;
```

- posix: g_prereserved_sandbox_size only exists on Linux, not on macOS

Fixup for:

- https://github.com/DaemonEngine/native_client/pull/24

This broke AppleClang macOS build:

```
src/trusted/service_runtime/posix/addrspace_teardown.c:21:7:
 error: use of undeclared identifier 'g_prereserved_sandbox_size'
   21 |   if (g_prereserved_sandbox_size > 0) {
      |       ^
1 error generated.
```