### PR TITLE
CMake plumbing to build tls_edit

### DIFF
--- a/src/tools/tls_edit/CMakeLists.txt
+++ b/src/tools/tls_edit/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(native_client C CXX)
+
+set(REPO_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../..")
+
+list(APPEND CMAKE_MODULE_PATH "${REPO_DIR}/cmake")
+
+include(Yokai/Detection)
+include(NaClFlags)
+
+if (NOT CMAKE_BUILD_TYPE)
+	set(CMAKE_BUILD_TYPE RelWithDebInfo)
+endif()
+
+include_directories("${REPO_DIR}/include-hax")
+include_directories("${REPO_DIR}/include")
+
+set(RDFA_VALIDATOR ON)
+add_subdirectory("${REPO_DIR}/src/trusted/validator_ragel" rdfa_validator)
+
+add_subdirectory("${REPO_DIR}/src/shared/platform" platform)
+add_subdirectory("${REPO_DIR}/src/shared/gio" gio)
+
+add_executable(tls_edit tls_edit.c)
+target_link_libraries(tls_edit rdfa_validator platform gio)
+install(TARGETS tls_edit DESTINATION bin)
+

--- a/src/trusted/validator_ragel/CMakeLists.txt
+++ b/src/trusted/validator_ragel/CMakeLists.txt
@@ -1,14 +1,13 @@
 add_definitions("-DVALIDATOR_EXPORT=DLLEXPORT")
 
-# src/trusted/validator_ragel/build.scons built both for both bitness
-# because it was needed for the rdfa_validator library which looks to
-# only be used for running some benchmark.
-if (YOKAI_TARGET_ARCH_I686)
-	set(VALIDATOR_LIB validator32)
-	add_library(${VALIDATOR_LIB} OBJECT "gen/validator_x86_32.c")
-elseif (YOKAI_TARGET_ARCH_AMD64)
-	set(VALIDATOR_LIB validator64)
-	add_library(${VALIDATOR_LIB} OBJECT "gen/validator_x86_64.c")
+# RDFA_VALIDATOR is set to ON when building tls_edit.
+
+if (YOKAI_TARGET_ARCH_I686 OR RDFA_VALIDATOR)
+	add_library(validator32 OBJECT "gen/validator_x86_32.c")
+	list(APPEND VALIDATOR_LIBS validator32)
+elseif (YOKAI_TARGET_ARCH_AMD64 OR RDFA_VALIDATOR)
+	add_library(validator64 OBJECT "gen/validator_x86_64.c")
+	list(APPEND VALIDATOR_LIBS validator64)
 endif()
 
 add_library(validator_features_all OBJECT "validator_features_all.c")
@@ -28,7 +27,12 @@ elseif (YOKAI_TARGET_ARCH_AMD64)
 	)
 endif()
 
+if (RDFA_VALIDATOR)
+	add_library(rdfa_validator)
+	target_link_libraries(rdfa_validator ${FEATURES_LIBS} ${VALIDATOR_LIBS})
+endif()
+
 add_library(dfa_validate_caller${VALIDATOR_ARCH_SUFFIX} STATIC ${DFA_VALIDATE_CALLER_INPUTS})
-target_link_libraries(dfa_validate_caller${VALIDATOR_ARCH_SUFFIX} ${FEATURES_LIBS} ${VALIDATOR_LIB})
+target_link_libraries(dfa_validate_caller${VALIDATOR_ARCH_SUFFIX} ${FEATURES_LIBS} ${VALIDATOR_LIBS})
 
 add_library(dfa_validate_caller ALIAS dfa_validate_caller${VALIDATOR_ARCH_SUFFIX})


### PR DESCRIPTION
CMake plumbing to build `tls_edit`.

Requires:

- https://github.com/DaemonEngine/native_client/pull/14

To build it, use `src/tools/tls_edit` as CMake source dir, not the main one building the loader.