### PR TITLE
Use Visual Studio's clang-cl if clang=1 in the Windows build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2261,13 +2261,18 @@ def SetUpClang(env):
                            '-fno-omit-frame-pointer',
                            '-DMEMORY_SANITIZER'])
 
-  env['CC'] = '${CLANG_DIR}/clang ${CLANG_OPTS}'
-  env['CXX'] = '${CLANG_DIR}/clang++ ${CLANG_OPTS}'
-  # Make sure we find Clang-supplied libraries like -lprofile_rt
-  # in the Clang build we use, rather than from the system.
-  # The system-installed versions go with the system-installed Clang
-  # and might not be compatible with the Clang we're running.
-  env.Append(LIBPATH=['${CLANG_DIR}/../lib'])
+  if env.Bit('host_windows'):
+    # Use the clang-cl shipped with Visual Studio
+    env['CC'] = 'clang-cl ${CLANG_OPTS}'
+    env['CXX'] = 'clang-cl ${CLANG_OPTS}'
+  else:
+    env['CC'] = '${CLANG_DIR}/clang ${CLANG_OPTS}'
+    env['CXX'] = '${CLANG_DIR}/clang++ ${CLANG_OPTS}'
+    # Make sure we find Clang-supplied libraries like -lprofile_rt
+    # in the Clang build we use, rather than from the system.
+    # The system-installed versions go with the system-installed Clang
+    # and might not be compatible with the Clang we're running.
+    env.Append(LIBPATH=['${CLANG_DIR}/../lib'])
 
 def GenerateOptimizationLevels(env):
   if env.Bit('clang') and not env.Bit('built_elsewhere'):
@@ -3694,7 +3699,7 @@ def DumpCompilerVersion(cc, env):
     env.Execute(env.Action('${CC} -v -c'))
     env.Execute(env.Action('${CC} -print-search-dirs'))
     env.Execute(env.Action('${CC} -print-libgcc-file-name'))
-  elif cc.startswith('cl'):
+  elif cc == 'cl':
     import subprocess
     try:
       p = subprocess.Popen(env.subst('${CC} /V'),

--- a/SConstruct
+++ b/SConstruct
@@ -2735,7 +2735,7 @@ def MakeGenericLinuxEnv(platform=None):
   # noexecstack: ensure that the executable does not get a PT_GNU_STACK
   #              header that causes the kernel to set the READ_IMPLIES_EXEC
   #              personality flag, which disables NX page protection.
-  linux_env.Prepend(CPPDEFINES=[['-D_FORTIFY_SOURCE', '2']])
+  linux_env.Prepend(CPPDEFINES=['_FORTIFY_SOURCE=2'])
   # By default SHLINKFLAGS uses $LINKFLAGS, but we do not want -pie
   # in $SHLINKFLAGS, only in $LINKFLAGS.  So move LINKFLAGS over to
   # COMMON_LINKFLAGS, and add the "hardening" options there.  Then
@@ -2755,7 +2755,7 @@ def MakeGenericLinuxEnv(platform=None):
     linux_env.Prepend(CCFLAGS=['-fPIC'])
     # TODO(mcgrathr): Temporarily punt _FORTIFY_SOURCE for ARM because
     # it causes a libc dependency newer than the old bots have installed.
-    linux_env.FilterOut(CPPDEFINES=[['-D_FORTIFY_SOURCE', '2']])
+    linux_env.FilterOut(CPPDEFINES=['_FORTIFY_SOURCE=2'])
   else:
     linux_env.Prepend(CCFLAGS=['-fPIE'])
 

--- a/src/trusted/service_runtime/build.scons
+++ b/src/trusted/service_runtime/build.scons
@@ -113,9 +113,9 @@ elif env.Bit('build_x86_64'):
   else:
     ldr_inputs += ['arch/x86_64/sel_addrspace_posix_x86_64.c']
   if env.Bit('x86_64_zero_based_sandbox'):
-    env.Append(CPPDEFINES=['-DNACL_X86_64_ZERO_BASED_SANDBOX=1'])
+    env.Append(CPPDEFINES=['NACL_X86_64_ZERO_BASED_SANDBOX=1'])
   else:
-    env.Append(CPPDEFINES=['-DNACL_X86_64_ZERO_BASED_SANDBOX=0'])
+    env.Append(CPPDEFINES=['NACL_X86_64_ZERO_BASED_SANDBOX=0'])
 elif env.Bit('build_arm'):
   ldr_inputs += [
     'arch/arm/nacl_app.c',


### PR DESCRIPTION
The tests all pass with `clang-cl` substituted for `cl`. The only adjustment needed was fixing a malformed preprocessor define flag.