### PR TITLE
Scons toolchain setup tweaks

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3696,8 +3696,10 @@ def DumpCompilerVersion(cc, env):
     env.Execute(env.Action('${CC} -print-libgcc-file-name'))
   elif cc.startswith('cl'):
     import subprocess
+    oldpath = os.environ['PATH']
+    os.environ['PATH'] = env['ENV']['PATH']
     try:
-      p = subprocess.Popen(env.subst('${CC} /V'),
+      p = subprocess.Popen([env.subst('${CC}')],
                            text=True,
                            bufsize=1000*1000,
                            stdout=subprocess.PIPE,
@@ -3705,10 +3707,9 @@ def DumpCompilerVersion(cc, env):
       stdout, stderr = p.communicate()
       print(stderr[0:stderr.find("\n")])
     except WindowsError:
-      # If vcvars was not run before running SCons, we won't be able to find
-      # the compiler at this point.  SCons has built in functions for finding
-      # the compiler, but they haven't run yet.
-      print('Can not find the compiler, assuming SCons will find it later.')
+      print('Cannot find the compiler (cl)!')
+    finally:
+      os.environ['PATH'] = oldpath
   else:
     print("UNKNOWN COMPILER")
 

--- a/SConstruct
+++ b/SConstruct
@@ -3698,11 +3698,12 @@ def DumpCompilerVersion(cc, env):
     import subprocess
     try:
       p = subprocess.Popen(env.subst('${CC} /V'),
+                           text=True,
                            bufsize=1000*1000,
                            stdout=subprocess.PIPE,
                            stderr=subprocess.PIPE)
       stdout, stderr = p.communicate()
-      print(stderr[0:stderr.find("\r")])
+      print(stderr[0:stderr.find("\n")])
     except WindowsError:
       # If vcvars was not run before running SCons, we won't be able to find
       # the compiler at this point.  SCons has built in functions for finding

--- a/tests/run_py/nacl.scons
+++ b/tests/run_py/nacl.scons
@@ -21,7 +21,7 @@ elif env.Bit('nacl_glibc'):
   # With the new glibc port, it won't work at all.
   Return()
 
-if env['TRUSTED_ENV'].Bit('windows'):
+if 'TRUSTED_ENV' in env and env['TRUSTED_ENV'].Bit('windows'):
   # To find readelf. Saigo also has a readelf but it's named x86_64-nacl-readelf (etc.)
   env = env.Clone()
   env.PrependENVPath('PATH', env['TRUSTED_ENV']['MINGW_BIN'])


### PR DESCRIPTION
Fix another SCons build regression with `--mode=nacl` (only) builds. Also fix printing the MSVC version.