### PR TITLE
More MinGW compatibility fixes to the source code

### DIFF
--- a/src/include/checked_cast.h
+++ b/src/include/checked_cast.h
@@ -16,12 +16,6 @@
 
 #include "native_client/src/include/build_config.h"
 
-// Windows defines std::min and std::max in a different header
-// than gcc prior to Visual Studio 2013.
-#if NACL_WINDOWS
-#include <xutility>
-#endif
-
 #include <algorithm>
 #include <limits>
 

--- a/src/include/concurrency_ops.h
+++ b/src/include/concurrency_ops.h
@@ -66,9 +66,9 @@ static INLINE void NaClFlushCacheForDoublyMappedCode(uint8_t *writable_addr,
    * We simply prevent the compiler from moving loads or stores around
    * this function.
    */
-  UNREFERENCED_PARAMETER(writable_addr);
-  UNREFERENCED_PARAMETER(executable_addr);
-  UNREFERENCED_PARAMETER(size);
+  NACL_UNUSED_PARAMETER(writable_addr);
+  NACL_UNUSED_PARAMETER(executable_addr);
+  NACL_UNUSED_PARAMETER(size);
 #if NACL_WINDOWS
   _ReadWriteBarrier();
 #else

--- a/src/include/nacl_compiler_annotations.h
+++ b/src/include/nacl_compiler_annotations.h
@@ -33,9 +33,9 @@
 #endif
 
 #if NACL_WINDOWS
-# define UNREFERENCED_PARAMETER(P) (P)
+# define NACL_UNUSED_PARAMETER(P) (P)
 #else
-# define UNREFERENCED_PARAMETER(P) do { (void) P; } while (0)
+# define NACL_UNUSED_PARAMETER(P) do { (void) P; } while (0)
 #endif
 
 #if NACL_WINDOWS

--- a/src/shared/imc/linux/nacl_imc.cc
+++ b/src/shared/imc/linux/nacl_imc.cc
@@ -48,16 +48,16 @@ static size_t GetRights(struct msghdr* msg, int* fdv) {
  * functions so that sigpipe_test continues to link.
  */
 NaClHandle NaClBoundSocket(const NaClSocketAddress* address) {
-  UNREFERENCED_PARAMETER(address);
+  NACL_UNUSED_PARAMETER(address);
   NaClLog(LOG_FATAL, "BoundSocket(): Not used on Linux\n");
   return -1;
 }
 
 int NaClSendDatagramTo(const NaClMessageHeader* message, int flags,
                        const NaClSocketAddress* name) {
-  UNREFERENCED_PARAMETER(message);
-  UNREFERENCED_PARAMETER(flags);
-  UNREFERENCED_PARAMETER(name);
+  NACL_UNUSED_PARAMETER(message);
+  NACL_UNUSED_PARAMETER(flags);
+  NACL_UNUSED_PARAMETER(name);
   NaClLog(LOG_FATAL, "SendDatagramTo(): Not used on Linux\n");
   return -1;
 }

--- a/src/shared/imc/osx/nacl_imc.cc
+++ b/src/shared/imc/osx/nacl_imc.cc
@@ -153,16 +153,16 @@ static bool IgnoreSIGPIPE() {
  * functions so that sigpipe_test continues to link.
  */
 NaClHandle NaClBoundSocket(const NaClSocketAddress* address) {
-  UNREFERENCED_PARAMETER(address);
+  NACL_UNUSED_PARAMETER(address);
   NaClLog(LOG_FATAL, "BoundSocket(): Not used on OSX\n");
   return -1;
 }
 
 int NaClSendDatagramTo(const NaClMessageHeader* message, int flags,
                        const NaClSocketAddress* name) {
-  UNREFERENCED_PARAMETER(message);
-  UNREFERENCED_PARAMETER(flags);
-  UNREFERENCED_PARAMETER(name);
+  NACL_UNUSED_PARAMETER(message);
+  NACL_UNUSED_PARAMETER(flags);
+  NACL_UNUSED_PARAMETER(name);
   NaClLog(LOG_FATAL, "SendDatagramTo(): Not used on OSX\n");
   return -1;
 }
@@ -206,7 +206,7 @@ int NaClSendDatagram(NaClHandle handle, const NaClMessageHeader* message,
   Header header = { 0, 0 };
   int result;
   size_t i;
-  UNREFERENCED_PARAMETER(flags);
+  NACL_UNUSED_PARAMETER(flags);
 
   assert(CMSG_SPACE(NACL_HANDLE_COUNT_MAX * sizeof(int))
          <= CMSG_SPACE_KHANDLE_COUNT_MAX_INTS);

--- a/src/shared/imc/posix/nacl_imc_posix.cc
+++ b/src/shared/imc/posix/nacl_imc_posix.cc
@@ -228,7 +228,7 @@ void* NaClMap(struct NaClDescEffector* effp,
     PROT_READ | PROT_WRITE | PROT_EXEC
   };
   int adjusted = 0;
-  UNREFERENCED_PARAMETER(effp);
+  NACL_UNUSED_PARAMETER(effp);
 
   if (flags & NACL_ABI_MAP_SHARED) {
     adjusted |= MAP_SHARED;

--- a/src/shared/imc/win/nacl_imc.cc
+++ b/src/shared/imc/win/nacl_imc.cc
@@ -520,7 +520,7 @@ int NaClReceiveDatagram(NaClHandle handle, NaClMessageHeader* message,
    * If handle is a bound socket, it is a named pipe in non-blocking mode.
    * Set is_bound_socket to true if handle has been created by BoundSocket().
    */
-  if (!GetNamedPipeHandleState(handle, &state, NULL, NULL, NULL, NULL, NULL)) {
+  if (!GetNamedPipeHandleState(handle, &state, NULL, NULL, NULL, NULL, 0)) {
     return -1;
   }
 

--- a/src/shared/platform/nacl_host_desc_big_file_test.c
+++ b/src/shared/platform/nacl_host_desc_big_file_test.c
@@ -206,7 +206,7 @@ static size_t ReadAndCheckLineRange(struct NaClHostDesc *d,
 
 /* visitor for computing number of bytes needed to hold line |ix| */
 static size_t BytesNeededForLineRangeOp(void *params, size_t ix) {
-  UNREFERENCED_PARAMETER(params);
+  NACL_UNUSED_PARAMETER(params);
   return strlen(quotes[ix]);
 }
 
@@ -345,7 +345,7 @@ static int CheckedPWriteFn(ssize_t (*fn)(struct NaClHostDesc *d,
 static size_t BasicReadWriteTest(struct NaClHostDesc *d, void *test_specifics) {
   size_t error_count = 0;
 
-  UNREFERENCED_PARAMETER(test_specifics);
+  NACL_UNUSED_PARAMETER(test_specifics);
 
   CheckedSeek(d, ((nacl_off64_t) 0), 0);
   error_count += ReadAndCheckLineRange(d, 0, LINES_AT_ZERO);
@@ -406,7 +406,7 @@ size_t BasicPReadTest(struct NaClHostDesc *d, void *test_specifics) {
   static size_t const kNullBytesInHole = 17;
   size_t available_bytes;
 
-  UNREFERENCED_PARAMETER(test_specifics);
+  NACL_UNUSED_PARAMETER(test_specifics);
 
   offset_last_line = BytesNeededForLineRange(0, LINES_AT_ZERO - 1);
   memset(buffer, 0, sizeof buffer);

--- a/src/shared/platform/nacl_host_desc_mmap_test.c
+++ b/src/shared/platform/nacl_host_desc_mmap_test.c
@@ -46,7 +46,7 @@ int prot_exec_test(struct NaClHostDesc *d, void *test_specifics) {
   int param;
   int value;
 
-  UNREFERENCED_PARAMETER(test_specifics);
+  NACL_UNUSED_PARAMETER(test_specifics);
 
   if ((uintptr_t) -4095 <
       (addr = NaClHostDescMap(d,
@@ -87,7 +87,7 @@ int map_shared_test(struct NaClHostDesc *d, void *test_specifics) {
   char *v1ptr;
   char *v2ptr;
 
-  UNREFERENCED_PARAMETER(test_specifics);
+  NACL_UNUSED_PARAMETER(test_specifics);
 
   if ((uintptr_t) -4095 <
       (view1 = NaClHostDescMap(d,

--- a/src/shared/platform/nacl_host_desc_pread_pwrite_test.c
+++ b/src/shared/platform/nacl_host_desc_pread_pwrite_test.c
@@ -359,7 +359,7 @@ int SeekPastEndAndWriteTest(struct NaClHostDesc *test_file,
   int err;
   nacl_off64_t seek_result;
 
-  UNREFERENCED_PARAMETER(test_params);
+  NACL_UNUSED_PARAMETER(test_params);
   err = NaClHostDescFstat(test_file, &stbuf);
   if (0 != err) {
     fprintf(stderr, "SeekPastEndAndWriteTest: fstat failed\n");
@@ -398,8 +398,8 @@ int PReadWithNegativeOffset(struct NaClHostDesc *test_file,
   char buffer[1<<16];
   ssize_t result;
 
-  UNREFERENCED_PARAMETER(ro_view);
-  UNREFERENCED_PARAMETER(test_params);
+  NACL_UNUSED_PARAMETER(ro_view);
+  NACL_UNUSED_PARAMETER(test_params);
 
   result = NaClHostDescPRead(test_file, buffer, sizeof buffer, -10);
   if (result != -NACL_ABI_EINVAL) {
@@ -434,8 +434,8 @@ int PWriteUsesOffsetSeekReadVerification(struct NaClHostDesc *test_file,
   ssize_t io_rv;
   nacl_off64_t seek_err;
 
-  UNREFERENCED_PARAMETER(ro_view);
-  UNREFERENCED_PARAMETER(test_params);
+  NACL_UNUSED_PARAMETER(ro_view);
+  NACL_UNUSED_PARAMETER(test_params);
 
   CHECK(len <= sizeof buffer);
 
@@ -499,7 +499,7 @@ int PWriteUsesOffsetPReadVerification(struct NaClHostDesc *test_file,
   char buffer[4096];
   ssize_t io_rv;
 
-  UNREFERENCED_PARAMETER(test_params);
+  NACL_UNUSED_PARAMETER(test_params);
 
   CHECK(len <= sizeof buffer);
 
@@ -557,7 +557,7 @@ int PWriteUsesOffsetReadPtrVerification(struct NaClHostDesc *test_file,
   ssize_t io_rv;
   const size_t pwrite_position = 4096;
 
-  UNREFERENCED_PARAMETER(test_params);
+  NACL_UNUSED_PARAMETER(test_params);
 
   seek_err = NaClHostDescSeek(test_file, 0, 0);
   if (seek_err < 0) {

--- a/src/shared/platform/nacl_interruptible_condvar.c
+++ b/src/shared/platform/nacl_interruptible_condvar.c
@@ -90,7 +90,7 @@ void NaClIntrCondVarIntr(struct NaClIntrCondVar *cp) {
 }
 
 void NaClIntrCondVarReset(struct NaClIntrCondVar *cp) {
-  UNREFERENCED_PARAMETER(cp);
+  NACL_UNUSED_PARAMETER(cp);
   /* nothing to do here - we don't keep status */
   return;
 }

--- a/src/shared/platform/osx/nacl_semaphore.c
+++ b/src/shared/platform/osx/nacl_semaphore.c
@@ -77,7 +77,7 @@ NaClSyncStatus NaClSemPost(struct NaClSemaphore *sem) {
 }
 
 int32_t NaClSemGetValue(struct NaClSemaphore *sem) {
-  UNREFERENCED_PARAMETER(sem);
+  NACL_UNUSED_PARAMETER(sem);
   return -1;
   /*
   * TODO(gregoryd) - sem_getvalue is declared but not implemented on OSX

--- a/src/shared/platform/posix/nacl_host_desc.c
+++ b/src/shared/platform/posix/nacl_host_desc.c
@@ -192,11 +192,11 @@ static INLINE void NaClHostDescInit(void) {
 }
 
 static INLINE void NaClHostDescExclusiveLock(int host_desc) {
-  UNREFERENCED_PARAMETER(host_desc);
+  NACL_UNUSED_PARAMETER(host_desc);
 }
 
 static INLINE void NaClHostDescExclusiveUnlock(int host_desc) {
-  UNREFERENCED_PARAMETER(host_desc);
+  NACL_UNUSED_PARAMETER(host_desc);
 }
 
 #endif
@@ -217,7 +217,7 @@ uintptr_t NaClHostDescMap(struct NaClHostDesc *d,
   int   tmp_prot;
   int   host_flags;
   int   need_exec;
-  UNREFERENCED_PARAMETER(effp);
+  NACL_UNUSED_PARAMETER(effp);
 
   NaClLog(4,
           ("NaClHostDescMap(0x%08"NACL_PRIxPTR", "

--- a/src/shared/platform/posix/nacl_secure_random.c
+++ b/src/shared/platform/posix/nacl_secure_random.c
@@ -80,9 +80,9 @@ int NaClSecureRngCtor(struct NaClSecureRng *self) {
 int NaClSecureRngTestingCtor(struct NaClSecureRng *self,
                              uint8_t              *seed_material,
                              size_t               seed_bytes) {
-  UNREFERENCED_PARAMETER(self);
-  UNREFERENCED_PARAMETER(seed_material);
-  UNREFERENCED_PARAMETER(seed_bytes);
+  NACL_UNUSED_PARAMETER(self);
+  NACL_UNUSED_PARAMETER(seed_material);
+  NACL_UNUSED_PARAMETER(seed_bytes);
   return 0;
 }
 

--- a/src/shared/platform/posix/nacl_threads.c
+++ b/src/shared/platform/posix/nacl_threads.c
@@ -107,7 +107,7 @@ void NaClThreadDtor(struct NaClThread *ntp) {
    * and the underlying thread library are responsible for ensuring
    * that resources such as the thread stack are properly released.
    */
-  UNREFERENCED_PARAMETER(ntp);
+  NACL_UNUSED_PARAMETER(ntp);
 }
 
 void NaClThreadJoin(struct NaClThread *ntp) {

--- a/src/shared/platform/posix/nacl_time.c
+++ b/src/shared/platform/posix/nacl_time.c
@@ -32,7 +32,7 @@ void NaClTimeInternalInit(struct NaClTimeState *ntsp) {
 }
 
 void NaClTimeInternalFini(struct NaClTimeState *ntsp) {
-  UNREFERENCED_PARAMETER(ntsp);
+  NACL_UNUSED_PARAMETER(ntsp);
 }
 
 uint64_t NaClTimerResolutionNsInternal(struct NaClTimeState *ntsp) {

--- a/src/shared/platform/win/nacl_host_desc.c
+++ b/src/shared/platform/win/nacl_host_desc.c
@@ -1410,7 +1410,7 @@ int NaClHostDescStat(char const *path, nacl_host_stat_t *nhsp) {
 }
 
 int NaClHostDescMkdir(const char *path, int mode) {
-  UNREFERENCED_PARAMETER(mode);
+  NACL_UNUSED_PARAMETER(mode);
   if (_mkdir(path) != 0)
     return -NaClXlateErrno(errno);
   return 0;

--- a/src/shared/platform/win/nacl_secure_random.c
+++ b/src/shared/platform/win/nacl_secure_random.c
@@ -49,8 +49,8 @@ int NaClSecureRngCtor(struct NaClSecureRng *self) {
 int NaClSecureRngTestingCtor(struct NaClSecureRng *self,
                              uint8_t              *seed_material,
                              size_t               seed_bytes) {
-  UNREFERENCED_PARAMETER(seed_material);
-  UNREFERENCED_PARAMETER(seed_bytes);
+  NACL_UNUSED_PARAMETER(seed_material);
+  NACL_UNUSED_PARAMETER(seed_bytes);
   self->base.vtbl = NULL;
   self->nvalid = 0;
   return 0;

--- a/src/shared/platform/win/nacl_semaphore.c
+++ b/src/shared/platform/win/nacl_semaphore.c
@@ -105,7 +105,7 @@ int32_t NaClSemGetValue(struct NaClSemaphore *sem) {
   NTSTATUS    status;
    */
   int32_t     count = -1;
-  UNREFERENCED_PARAMETER(sem);
+  NACL_UNUSED_PARAMETER(sem);
 /* TODO(gregoryd): cannot use NtQuerySemaphore without linking to ntdll.lib
   status = NtQuerySemaphore(
     sem->sem_handle,

--- a/src/shared/platform/win/nacl_time.c
+++ b/src/shared/platform/win/nacl_time.c
@@ -471,7 +471,7 @@ int NaClNanosleep(struct nacl_abi_timespec const *req,
   uint64_t                  resolution;
   DWORD                     resolution_gap = 0;
 
-  UNREFERENCED_PARAMETER(rem);
+  NACL_UNUSED_PARAMETER(rem);
 
   /* round up from ns resolution to ms resolution */
   /* TODO(bsy): report an error or loop if req->tv_sec does not fit in DWORD */

--- a/src/tools/tls_edit/tls_edit.c
+++ b/src/tools/tls_edit/tls_edit.c
@@ -85,7 +85,7 @@ static void EditMipsCode(void *code, size_t code_length) {
 
 static Bool ConsiderOneInsn(const uint8_t *insn_begin, const uint8_t *insn_end,
                             uint32_t validation_info, void *data) {
-  UNREFERENCED_PARAMETER(data);
+  NACL_UNUSED_PARAMETER(data);
   if (insn_begin[0] == 0x65) {  /* GS prefix */
     if (insn_end - insn_begin < 6) {
       ReportError(insn_begin, "Unexpected GS prefix");

--- a/src/trusted/debug_stub/nacl_debug.cc
+++ b/src/trusted/debug_stub/nacl_debug.cc
@@ -80,7 +80,7 @@ void NaClDebugStubSetPipe(NaClHandle handle) {
 }
 
 void WINAPI NaClStubThread(void *thread_arg) {
-  UNREFERENCED_PARAMETER(thread_arg);
+  NACL_UNUSED_PARAMETER(thread_arg);
   while (1) {
     // Wait for a connection.
     if (!g_transport->AcceptConnection()) continue;

--- a/src/trusted/debug_stub/session_test.cc
+++ b/src/trusted/debug_stub/session_test.cc
@@ -54,8 +54,8 @@ class DCSocketTransport : public port::ITransport {
 
   virtual void WaitForDebugStubEvent(struct NaClApp *nap,
                                      bool ignore_gdb) {
-    UNREFERENCED_PARAMETER(nap);
-    UNREFERENCED_PARAMETER(ignore_gdb);
+    NACL_UNUSED_PARAMETER(nap);
+    NACL_UNUSED_PARAMETER(ignore_gdb);
   }
 
   virtual void Disconnect() {}

--- a/src/trusted/debug_stub/target.cc
+++ b/src/trusted/debug_stub/target.cc
@@ -331,7 +331,7 @@ bool Target::IsOnValidInstBoundary(uint32_t addr) {
                   NACL_INSTR_BLOCK_SIZE,
                   nap_->cpu_features) == NaClValidationSucceeded;
 #else
-  UNREFERENCED_PARAMETER(addr);
+  NACL_UNUSED_PARAMETER(addr);
   return true;
 #endif
 }

--- a/src/trusted/debug_stub/thread_common.cc
+++ b/src/trusted/debug_stub/thread_common.cc
@@ -51,7 +51,7 @@ bool Thread::SetStep(bool on) {
   return true;
 #else
   // TODO(mseaborn): Implement for ARM.
-  UNREFERENCED_PARAMETER(on);
+  NACL_UNUSED_PARAMETER(on);
   return false;
 #endif
 }

--- a/src/trusted/debug_stub/win/platform_impl.cc
+++ b/src/trusted/debug_stub/win/platform_impl.cc
@@ -145,7 +145,7 @@ bool IPlatform::GetMemory(uint64_t virt, uint32_t len, void *dst) {
 
 bool IPlatform::SetMemory(struct NaClApp *nap, uint64_t virt, uint32_t len,
                           void *src) {
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
   uint32_t oldFlags = Reprotect(reinterpret_cast<void *>(virt),
                                 len, PAGE_READWRITE);
 

--- a/src/trusted/desc/metadata_test.c
+++ b/src/trusted/desc/metadata_test.c
@@ -255,7 +255,7 @@ void WINAPI child_thread_fn(void *child_thread_state) {
    * create and send a desc with flags, and then with metadata string,
    * and then with both.
    */
-  UNREFERENCED_PARAMETER(child_thread_state);
+  NACL_UNUSED_PARAMETER(child_thread_state);
   sender_thread();
   return;
 }

--- a/src/trusted/desc/nacl_desc_base.c
+++ b/src/trusted/desc/nacl_desc_base.c
@@ -239,7 +239,7 @@ char const *NaClDescTypeString(enum NaClDescTypeTag type_tag) {
 
 
 void NaClDescDtorNotImplemented(struct NaClRefCount  *vself) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
 
   NaClLog(LOG_FATAL, "Must implement a destructor!\n");
 }
@@ -251,12 +251,12 @@ uintptr_t NaClDescMapNotImplemented(struct NaClDesc         *vself,
                                     int                     prot,
                                     int                     flags,
                                     nacl_off64_t            offset) {
-  UNREFERENCED_PARAMETER(effp);
-  UNREFERENCED_PARAMETER(start_addr);
-  UNREFERENCED_PARAMETER(len);
-  UNREFERENCED_PARAMETER(prot);
-  UNREFERENCED_PARAMETER(flags);
-  UNREFERENCED_PARAMETER(offset);
+  NACL_UNUSED_PARAMETER(effp);
+  NACL_UNUSED_PARAMETER(start_addr);
+  NACL_UNUSED_PARAMETER(len);
+  NACL_UNUSED_PARAMETER(prot);
+  NACL_UNUSED_PARAMETER(flags);
+  NACL_UNUSED_PARAMETER(offset);
 
   NaClLog(LOG_ERROR,
           "Map method is not implemented for object of type %s\n",
@@ -268,8 +268,8 @@ uintptr_t NaClDescMapNotImplemented(struct NaClDesc         *vself,
 ssize_t NaClDescReadNotImplemented(struct NaClDesc          *vself,
                                    void                     *buf,
                                    size_t                   len) {
-  UNREFERENCED_PARAMETER(buf);
-  UNREFERENCED_PARAMETER(len);
+  NACL_UNUSED_PARAMETER(buf);
+  NACL_UNUSED_PARAMETER(len);
 
   NaClLog(LOG_ERROR,
           "Read method is not implemented for object of type %s\n",
@@ -281,8 +281,8 @@ ssize_t NaClDescReadNotImplemented(struct NaClDesc          *vself,
 ssize_t NaClDescWriteNotImplemented(struct NaClDesc         *vself,
                                     void const              *buf,
                                     size_t                  len) {
-  UNREFERENCED_PARAMETER(buf);
-  UNREFERENCED_PARAMETER(len);
+  NACL_UNUSED_PARAMETER(buf);
+  NACL_UNUSED_PARAMETER(len);
 
   NaClLog(LOG_ERROR,
           "Write method is not implemented for object of type %s\n",
@@ -294,8 +294,8 @@ ssize_t NaClDescWriteNotImplemented(struct NaClDesc         *vself,
 nacl_off64_t NaClDescSeekNotImplemented(struct NaClDesc          *vself,
                                         nacl_off64_t             offset,
                                         int                      whence) {
-  UNREFERENCED_PARAMETER(offset);
-  UNREFERENCED_PARAMETER(whence);
+  NACL_UNUSED_PARAMETER(offset);
+  NACL_UNUSED_PARAMETER(whence);
 
   NaClLog(LOG_ERROR,
           "Seek method is not implemented for object of type %s\n",
@@ -308,9 +308,9 @@ ssize_t NaClDescPReadNotImplemented(struct NaClDesc *vself,
                                     void *buf,
                                     size_t len,
                                     nacl_off64_t offset) {
-  UNREFERENCED_PARAMETER(buf);
-  UNREFERENCED_PARAMETER(len);
-  UNREFERENCED_PARAMETER(offset);
+  NACL_UNUSED_PARAMETER(buf);
+  NACL_UNUSED_PARAMETER(len);
+  NACL_UNUSED_PARAMETER(offset);
 
   NaClLog(LOG_ERROR,
           "PRead method is not implemented for object of type %s\n",
@@ -323,9 +323,9 @@ ssize_t NaClDescPWriteNotImplemented(struct NaClDesc *vself,
                                      void const *buf,
                                      size_t len,
                                      nacl_off64_t offset) {
-  UNREFERENCED_PARAMETER(buf);
-  UNREFERENCED_PARAMETER(len);
-  UNREFERENCED_PARAMETER(offset);
+  NACL_UNUSED_PARAMETER(buf);
+  NACL_UNUSED_PARAMETER(len);
+  NACL_UNUSED_PARAMETER(offset);
 
   NaClLog(LOG_ERROR,
           "PWrite method is not implemented for object of type %s\n",
@@ -336,7 +336,7 @@ ssize_t NaClDescPWriteNotImplemented(struct NaClDesc *vself,
 
 int NaClDescFstatNotImplemented(struct NaClDesc         *vself,
                                 struct nacl_abi_stat    *statbuf) {
-  UNREFERENCED_PARAMETER(statbuf);
+  NACL_UNUSED_PARAMETER(statbuf);
 
   NaClLog(LOG_ERROR,
           "Fstat method is not implemented for object of type %s\n",
@@ -355,7 +355,7 @@ int NaClDescFchdirNotImplemented(struct NaClDesc *vself) {
 
 int NaClDescFchmodNotImplemented(struct NaClDesc *vself,
                                  int             mode) {
-  UNREFERENCED_PARAMETER(mode);
+  NACL_UNUSED_PARAMETER(mode);
 
   NaClLog(LOG_ERROR,
           "Fchmod method is not implemented for object of type %s\n",
@@ -382,7 +382,7 @@ int NaClDescFdatasyncNotImplemented(struct NaClDesc *vself) {
 
 int NaClDescFtruncateNotImplemented(struct NaClDesc  *vself,
                                     nacl_abi_off_t   length) {
-  UNREFERENCED_PARAMETER(length);
+  NACL_UNUSED_PARAMETER(length);
 
   NaClLog(LOG_ERROR,
           "Ftruncate method is not implemented for object of type %s\n",
@@ -394,8 +394,8 @@ int NaClDescFtruncateNotImplemented(struct NaClDesc  *vself,
 ssize_t NaClDescGetdentsNotImplemented(struct NaClDesc          *vself,
                                        void                     *dirp,
                                        size_t                   count) {
-  UNREFERENCED_PARAMETER(dirp);
-  UNREFERENCED_PARAMETER(count);
+  NACL_UNUSED_PARAMETER(dirp);
+  NACL_UNUSED_PARAMETER(count);
 
   NaClLog(LOG_ERROR,
           "Getdents method is not implemented for object of type %s\n",
@@ -407,8 +407,8 @@ ssize_t NaClDescGetdentsNotImplemented(struct NaClDesc          *vself,
 int NaClDescExternalizeSizeNotImplemented(struct NaClDesc *vself,
                                           size_t          *nbytes,
                                           size_t          *nhandles) {
-  UNREFERENCED_PARAMETER(nbytes);
-  UNREFERENCED_PARAMETER(nhandles);
+  NACL_UNUSED_PARAMETER(nbytes);
+  NACL_UNUSED_PARAMETER(nhandles);
 
   NaClLog(LOG_ERROR,
           "ExternalizeSize method is not implemented for object of type %s\n",
@@ -419,7 +419,7 @@ int NaClDescExternalizeSizeNotImplemented(struct NaClDesc *vself,
 
 int NaClDescExternalizeNotImplemented(struct NaClDesc          *vself,
                                       struct NaClDescXferState *xfer) {
-  UNREFERENCED_PARAMETER(xfer);
+  NACL_UNUSED_PARAMETER(xfer);
 
   NaClLog(LOG_ERROR,
           "Externalize method is not implemented for object of type %s\n",
@@ -454,7 +454,7 @@ int NaClDescUnlockNotImplemented(struct NaClDesc  *vself) {
 
 int NaClDescWaitNotImplemented(struct NaClDesc  *vself,
                                struct NaClDesc  *mutex) {
-  UNREFERENCED_PARAMETER(mutex);
+  NACL_UNUSED_PARAMETER(mutex);
 
   NaClLog(LOG_ERROR,
           "Wait method is not implemented for object of type %s\n",
@@ -466,8 +466,8 @@ int NaClDescWaitNotImplemented(struct NaClDesc  *vself,
 int NaClDescTimedWaitAbsNotImplemented(struct NaClDesc                *vself,
                                        struct NaClDesc                *mutex,
                                        struct nacl_abi_timespec const *ts) {
-  UNREFERENCED_PARAMETER(mutex);
-  UNREFERENCED_PARAMETER(ts);
+  NACL_UNUSED_PARAMETER(mutex);
+  NACL_UNUSED_PARAMETER(ts);
 
   NaClLog(LOG_ERROR,
           "TimedWaitAbs method is not implemented for object of type %s\n",
@@ -496,8 +496,8 @@ ssize_t NaClDescSendMsgNotImplemented(
     struct NaClDesc                 *vself,
     const struct NaClImcTypedMsgHdr *nitmhp,
     int                             flags) {
-  UNREFERENCED_PARAMETER(nitmhp);
-  UNREFERENCED_PARAMETER(flags);
+  NACL_UNUSED_PARAMETER(nitmhp);
+  NACL_UNUSED_PARAMETER(flags);
 
   NaClLog(LOG_ERROR,
           "SendMsg method is not implemented for object of type %s\n",
@@ -510,8 +510,8 @@ ssize_t NaClDescRecvMsgNotImplemented(
     struct NaClDesc                 *vself,
     struct NaClImcTypedMsgHdr       *nitmhp,
     int                             flags) {
-  UNREFERENCED_PARAMETER(nitmhp);
-  UNREFERENCED_PARAMETER(flags);
+  NACL_UNUSED_PARAMETER(nitmhp);
+  NACL_UNUSED_PARAMETER(flags);
 
   NaClLog(LOG_ERROR,
           "RecvMsg method is not implemented for object of type %s\n",
@@ -524,8 +524,8 @@ ssize_t NaClDescLowLevelSendMsgNotImplemented(
     struct NaClDesc                *vself,
     struct NaClMessageHeader const *dgram,
     int                            flags) {
-  UNREFERENCED_PARAMETER(dgram);
-  UNREFERENCED_PARAMETER(flags);
+  NACL_UNUSED_PARAMETER(dgram);
+  NACL_UNUSED_PARAMETER(flags);
 
   NaClLog(LOG_ERROR,
           "LowLevelSendMsg method is not implemented for object of type %s\n",
@@ -538,8 +538,8 @@ ssize_t NaClDescLowLevelRecvMsgNotImplemented(
     struct NaClDesc           *vself,
     struct NaClMessageHeader  *dgram,
     int                       flags) {
-  UNREFERENCED_PARAMETER(dgram);
-  UNREFERENCED_PARAMETER(flags);
+  NACL_UNUSED_PARAMETER(dgram);
+  NACL_UNUSED_PARAMETER(flags);
 
   NaClLog(LOG_ERROR,
           "LowLevelRecvMsg method is not implemented for object of type %s\n",
@@ -550,7 +550,7 @@ ssize_t NaClDescLowLevelRecvMsgNotImplemented(
 
 int NaClDescConnectAddrNotImplemented(struct NaClDesc *vself,
                                       struct NaClDesc **result) {
-  UNREFERENCED_PARAMETER(result);
+  NACL_UNUSED_PARAMETER(result);
 
   NaClLog(LOG_ERROR,
           "ConnectAddr method is not implemented for object of type %s\n",
@@ -561,7 +561,7 @@ int NaClDescConnectAddrNotImplemented(struct NaClDesc *vself,
 
 int NaClDescAcceptConnNotImplemented(struct NaClDesc *vself,
                                      struct NaClDesc **result) {
-  UNREFERENCED_PARAMETER(result);
+  NACL_UNUSED_PARAMETER(result);
 
   NaClLog(LOG_ERROR,
           "AcceptConn method is not implemented for object of type %s\n",
@@ -597,8 +597,8 @@ int NaClDescGetValueNotImplemented(struct NaClDesc  *vself) {
 int NaClDescInternalizeNotImplemented(
     struct NaClDesc                **out_desc,
     struct NaClDescXferState       *xfer) {
-  UNREFERENCED_PARAMETER(out_desc);
-  UNREFERENCED_PARAMETER(xfer);
+  NACL_UNUSED_PARAMETER(out_desc);
+  NACL_UNUSED_PARAMETER(xfer);
 
   NaClLog(LOG_ERROR,
           "Attempted transfer of non-transferable descriptor\n");

--- a/src/trusted/desc/nacl_desc_cond.c
+++ b/src/trusted/desc/nacl_desc_cond.c
@@ -67,7 +67,7 @@ static void NaClDescCondVarDtor(struct NaClRefCount *vself) {
 
 static int NaClDescCondVarFstat(struct NaClDesc          *vself,
                                 struct nacl_abi_stat     *statbuf) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
 
   memset(statbuf, 0, sizeof *statbuf);
   statbuf->nacl_abi_st_mode = NACL_ABI_S_IFCOND | NACL_ABI_S_IRWXU;

--- a/src/trusted/desc/nacl_desc_conn_cap.c
+++ b/src/trusted/desc/nacl_desc_conn_cap.c
@@ -70,7 +70,7 @@ static void NaClDescConnCapDtor(struct NaClRefCount *vself) {
 
 static int NaClDescConnCapFstat(struct NaClDesc          *vself,
                                 struct nacl_abi_stat     *statbuf) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
 
   memset(statbuf, 0, sizeof *statbuf);
   statbuf->nacl_abi_st_mode = NACL_ABI_S_IFSOCKADDR | NACL_ABI_S_IRWXU;
@@ -82,7 +82,7 @@ static int NaClDescConnCapExternalizeSize(struct NaClDesc  *vself,
                                           size_t           *nhandles) {
   int rv;
 
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
 
   rv = NaClDescExternalizeSize(vself, nbytes, nhandles);
   if (0 != rv) {
@@ -184,8 +184,8 @@ cleanup:
 
 static int NaClDescConnCapAcceptConn(struct NaClDesc *vself,
                                      struct NaClDesc **out_desc) {
-  UNREFERENCED_PARAMETER(vself);
-  UNREFERENCED_PARAMETER(out_desc);
+  NACL_UNUSED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(out_desc);
 
   NaClLog(LOG_ERROR, "NaClDescConnCapAcceptConn: not IMC\n");
   return -NACL_ABI_EINVAL;

--- a/src/trusted/desc/nacl_desc_dir.c
+++ b/src/trusted/desc/nacl_desc_dir.c
@@ -130,7 +130,7 @@ static nacl_off64_t NaClDescDirDescSeek(struct NaClDesc *vself,
 
 static int NaClDescDirDescFstat(struct NaClDesc          *vself,
                                 struct nacl_abi_stat     *statbuf) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
 
   memset(statbuf, 0, sizeof *statbuf);
   /*

--- a/src/trusted/desc/nacl_desc_effector_trusted_mem.c
+++ b/src/trusted/desc/nacl_desc_effector_trusted_mem.c
@@ -17,9 +17,9 @@
 static void NaClDescEffTrustedMemUnmapMemory(struct NaClDescEffector  *vself,
                                              uintptr_t                sysaddr,
                                              size_t                   nbytes) {
-  UNREFERENCED_PARAMETER(vself);
-  UNREFERENCED_PARAMETER(sysaddr);
-  UNREFERENCED_PARAMETER(nbytes);
+  NACL_UNUSED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(sysaddr);
+  NACL_UNUSED_PARAMETER(nbytes);
   NaClLog(8, "TrustedMem effector's UnmapMemory called, nothing to do\n");
 }
 

--- a/src/trusted/desc/nacl_desc_imc.c
+++ b/src/trusted/desc/nacl_desc_imc.c
@@ -158,7 +158,7 @@ static void NaClDescXferableDataDescDtor(struct NaClRefCount *vself) {
 
 int NaClDescImcDescFstat(struct NaClDesc          *vself,
                          struct nacl_abi_stat     *statbuf) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
 
   memset(statbuf, 0, sizeof *statbuf);
   statbuf->nacl_abi_st_mode = (NACL_ABI_S_IFSOCK |
@@ -169,7 +169,7 @@ int NaClDescImcDescFstat(struct NaClDesc          *vself,
 
 static int NaClDescXferableDataDescFstat(struct NaClDesc          *vself,
                                          struct nacl_abi_stat     *statbuf) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
 
   memset(statbuf, 0, sizeof *statbuf);
   statbuf->nacl_abi_st_mode = NACL_ABI_S_IFDSOCK;
@@ -181,7 +181,7 @@ static int NaClDescXferableDataDescExternalizeSize(struct NaClDesc  *vself,
                                                    size_t           *nhandles) {
   int rv;
 
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
   NaClLog(4, "Entered NaClDescXferableDataDescExternalizeSize\n");
   rv = NaClDescExternalizeSize(vself, nbytes, nhandles);
   if (0 != rv) {

--- a/src/trusted/desc/nacl_desc_imc_bound_desc.c
+++ b/src/trusted/desc/nacl_desc_imc_bound_desc.c
@@ -54,7 +54,7 @@ static void NaClDescImcBoundDescDtor(struct NaClRefCount *vself) {
 
 static int NaClDescImcBoundDescFstat(struct NaClDesc          *vself,
                                      struct nacl_abi_stat     *statbuf) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
 
   memset(statbuf, 0, sizeof *statbuf);
   statbuf->nacl_abi_st_mode = NACL_ABI_S_IFBOUNDSOCK;

--- a/src/trusted/desc/nacl_desc_invalid.c
+++ b/src/trusted/desc/nacl_desc_invalid.c
@@ -32,7 +32,7 @@
 static int NaClDescInvalidExternalizeSize(struct NaClDesc      *vself,
                                           size_t               *nbytes,
                                           size_t               *nhandles) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
   *nbytes = 0;
   *nhandles = 0;
   return 0;
@@ -40,8 +40,8 @@ static int NaClDescInvalidExternalizeSize(struct NaClDesc      *vself,
 
 static int NaClDescInvalidExternalize(struct NaClDesc          *vself,
                                       struct NaClDescXferState *xfer) {
-  UNREFERENCED_PARAMETER(vself);
-  UNREFERENCED_PARAMETER(xfer);
+  NACL_UNUSED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(xfer);
   return 0;
 }
 
@@ -148,7 +148,7 @@ struct NaClDescInvalid const *NaClDescInvalidMake(void) {
 
 int NaClDescInvalidInternalize(struct NaClDesc               **baseptr,
                                struct NaClDescXferState      *xfer) {
-  UNREFERENCED_PARAMETER(xfer);
+  NACL_UNUSED_PARAMETER(xfer);
 
   *baseptr = (struct NaClDesc *) NaClDescInvalidMake();
 

--- a/src/trusted/desc/nacl_desc_mutex.c
+++ b/src/trusted/desc/nacl_desc_mutex.c
@@ -69,7 +69,7 @@ static void NaClDescMutexDtor(struct NaClRefCount *vself) {
 
 static int NaClDescMutexFstat(struct NaClDesc          *vself,
                               struct nacl_abi_stat     *statbuf) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
 
   memset(statbuf, 0, sizeof *statbuf);
   statbuf->nacl_abi_st_mode = NACL_ABI_S_IFMUTEX;

--- a/src/trusted/desc/nacl_desc_null.c
+++ b/src/trusted/desc/nacl_desc_null.c
@@ -38,9 +38,9 @@ static void NaClDescNullDtor(struct NaClRefCount *vself) {
 static ssize_t NaClDescNullRead(struct NaClDesc *vself,
                                void *buf,
                                size_t len) {
-  UNREFERENCED_PARAMETER(vself);
-  UNREFERENCED_PARAMETER(buf);
-  UNREFERENCED_PARAMETER(len);
+  NACL_UNUSED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(buf);
+  NACL_UNUSED_PARAMETER(len);
 
   return 0;
 }
@@ -48,8 +48,8 @@ static ssize_t NaClDescNullRead(struct NaClDesc *vself,
 static ssize_t NaClDescNullWrite(struct NaClDesc *vself,
                                 void const *buf,
                                 size_t len) {
-  UNREFERENCED_PARAMETER(vself);
-  UNREFERENCED_PARAMETER(buf);
+  NACL_UNUSED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(buf);
 
   return len;
 }
@@ -58,9 +58,9 @@ static ssize_t NaClDescNullPRead(struct NaClDesc *vself,
                                  void *buf,
                                  size_t len,
                                  nacl_off64_t offset) {
-  UNREFERENCED_PARAMETER(vself);
-  UNREFERENCED_PARAMETER(buf);
-  UNREFERENCED_PARAMETER(len);
+  NACL_UNUSED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(buf);
+  NACL_UNUSED_PARAMETER(len);
   if (offset < 0) {
     return -NACL_ABI_EINVAL;
   }
@@ -72,8 +72,8 @@ static ssize_t NaClDescNullPWrite(struct NaClDesc *vself,
                                   void const *buf,
                                   size_t len,
                                   nacl_off64_t offset) {
-  UNREFERENCED_PARAMETER(vself);
-  UNREFERENCED_PARAMETER(buf);
+  NACL_UNUSED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(buf);
   if (offset < 0) {
     return -NACL_ABI_EINVAL;
   }
@@ -83,7 +83,7 @@ static ssize_t NaClDescNullPWrite(struct NaClDesc *vself,
 
 static int NaClDescNullFstat(struct NaClDesc *vself,
                             struct nacl_abi_stat *statbuf) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
 
   memset(statbuf, 0, sizeof *statbuf);
   statbuf->nacl_abi_st_dev = 0;
@@ -116,7 +116,7 @@ static int NaClDescNullFstat(struct NaClDesc *vself,
 static int NaClDescNullExternalizeSize(struct NaClDesc *vself,
                                        size_t *nbytes,
                                        size_t *nhandles) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
 
   *nbytes = 0;
   *nhandles = 0;
@@ -125,8 +125,8 @@ static int NaClDescNullExternalizeSize(struct NaClDesc *vself,
 
 static int NaClDescNullExternalize(struct NaClDesc *vself,
                                    struct NaClDescXferState *xfer) {
-  UNREFERENCED_PARAMETER(vself);
-  UNREFERENCED_PARAMETER(xfer);
+  NACL_UNUSED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(xfer);
 
   return 0;
 }
@@ -179,7 +179,7 @@ int NaClDescNullInternalize(struct NaClDesc **out_desc,
   int rv;
   struct NaClDescNull *d_null = malloc(sizeof *d_null);
 
-  UNREFERENCED_PARAMETER(xfer);
+  NACL_UNUSED_PARAMETER(xfer);
   if (NULL == d_null) {
     rv = -NACL_ABI_ENOMEM;
     goto cleanup;

--- a/src/trusted/desc/nacl_desc_quota_interface.c
+++ b/src/trusted/desc/nacl_desc_quota_interface.c
@@ -54,10 +54,10 @@ int64_t NaClDescQuotaInterfaceWriteRequestNotImplemented(
     uint8_t const                  *file_id,
     int64_t                        offset,
     int64_t                        length) {
-  UNREFERENCED_PARAMETER(vself);
-  UNREFERENCED_PARAMETER(file_id);
-  UNREFERENCED_PARAMETER(offset);
-  UNREFERENCED_PARAMETER(length);
+  NACL_UNUSED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(file_id);
+  NACL_UNUSED_PARAMETER(offset);
+  NACL_UNUSED_PARAMETER(length);
   NaClLog(LOG_FATAL, "NaClDescQuotaInterface: WriteRequest not implemented.");
   return 0;
 }
@@ -66,9 +66,9 @@ int64_t NaClDescQuotaInterfaceFtruncateRequestNotImplemented(
     struct NaClDescQuotaInterface  *vself,
     uint8_t const                  *file_id,
     int64_t                        length) {
-  UNREFERENCED_PARAMETER(vself);
-  UNREFERENCED_PARAMETER(file_id);
-  UNREFERENCED_PARAMETER(length);
+  NACL_UNUSED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(file_id);
+  NACL_UNUSED_PARAMETER(length);
   NaClLog(LOG_FATAL,
           "NaClDescQuotaInterface: FtruncateRequest not implemented.");
   return 0;

--- a/src/trusted/desc/nacl_desc_quota_test.c
+++ b/src/trusted/desc/nacl_desc_quota_test.c
@@ -60,9 +60,9 @@ static int64_t FakeWriteRequest(struct NaClDescQuotaInterface *quota_interface,
                                 uint8_t const                 *file_id,
                                 int64_t                       offset,
                                 int64_t                       length) {
-  UNREFERENCED_PARAMETER(quota_interface);
-  UNREFERENCED_PARAMETER(file_id);
-  UNREFERENCED_PARAMETER(offset);
+  NACL_UNUSED_PARAMETER(quota_interface);
+  NACL_UNUSED_PARAMETER(file_id);
+  NACL_UNUSED_PARAMETER(offset);
 
   NaClLog(1,
           ("NaClSrpcPepperWriteRequest(dummy): requesting length %"NACL_PRId64
@@ -88,8 +88,8 @@ static int64_t FakeFtruncateRequest(
     struct NaClDescQuotaInterface *quota_interface,
     uint8_t const                 *file_id,
     int64_t                       length) {
-  UNREFERENCED_PARAMETER(quota_interface);
-  UNREFERENCED_PARAMETER(file_id);
+  NACL_UNUSED_PARAMETER(quota_interface);
+  NACL_UNUSED_PARAMETER(file_id);
 
   NaClLog(LOG_FATAL, "FtruncateRequest invoked!?!\n");
   return length;

--- a/src/trusted/desc/nacl_desc_semaphore.c
+++ b/src/trusted/desc/nacl_desc_semaphore.c
@@ -67,7 +67,7 @@ void NaClDescSemaphoreDtor(struct NaClRefCount *vself) {
 
 int NaClDescSemaphoreFstat(struct NaClDesc          *vself,
                            struct nacl_abi_stat     *statbuf) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
 
   memset(statbuf, 0, sizeof *statbuf);
   statbuf->nacl_abi_st_mode = NACL_ABI_S_IFSEMA;
@@ -89,7 +89,7 @@ int NaClDescSemaphoreSemWait(struct NaClDesc          *vself) {
 }
 
 int NaClDescSemaphoreGetValue(struct NaClDesc         *vself) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
 
   NaClLog(LOG_ERROR, "SemGetValue is not implemented yet\n");
   return -NACL_ABI_EINVAL;

--- a/src/trusted/desc/nacl_desc_sync_socket.c
+++ b/src/trusted/desc/nacl_desc_sync_socket.c
@@ -82,7 +82,7 @@ static void NaClDescSyncSocketDtor(struct NaClRefCount *vself) {
 
 static int NaClDescSyncSocketFstat(struct NaClDesc          *vself,
                                    struct nacl_abi_stat     *statbuf) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
 
   memset(statbuf, 0, sizeof *statbuf);
   statbuf->nacl_abi_st_mode = NACL_ABI_S_IFDSOCK;

--- a/src/trusted/desc/nrd_xfer.c
+++ b/src/trusted/desc/nrd_xfer.c
@@ -54,7 +54,7 @@ static INLINE size_t min_size(size_t  a,
 
 void NaClNrdXferIncrTagOverhead(size_t *byte_count,
                                 size_t *handle_count) {
-  UNREFERENCED_PARAMETER(handle_count);
+  NACL_UNUSED_PARAMETER(handle_count);
   ++*byte_count;
 }
 

--- a/src/trusted/desc/osx/nacl_desc_imc_shm_mach.c
+++ b/src/trusted/desc/osx/nacl_desc_imc_shm_mach.c
@@ -198,7 +198,7 @@ static uintptr_t NaClDescImcShmMachMap(struct NaClDesc *vself,
 
   void *result;
   nacl_off64_t tmp_off64;
-  UNREFERENCED_PARAMETER(effp);
+  NACL_UNUSED_PARAMETER(effp);
 
   /*
    * shm must have NACL_ABI_MAP_SHARED in flags, and all calls through

--- a/src/trusted/desc/posix/nacl_desc_conn_cap.c
+++ b/src/trusted/desc/posix/nacl_desc_conn_cap.c
@@ -69,7 +69,7 @@ static void NaClDescConnCapFdDtor(struct NaClRefCount *vself) {
 
 static int NaClDescConnCapFdFstat(struct NaClDesc       *vself,
                                   struct nacl_abi_stat  *statbuf) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
 
   memset(statbuf, 0, sizeof *statbuf);
   statbuf->nacl_abi_st_mode = NACL_ABI_S_IFSOCKADDR | NACL_ABI_S_IRWXU;
@@ -245,8 +245,8 @@ cleanup:
 
 static int NaClDescConnCapFdAcceptConn(struct NaClDesc  *vself,
                                        struct NaClDesc  **out_desc) {
-  UNREFERENCED_PARAMETER(vself);
-  UNREFERENCED_PARAMETER(out_desc);
+  NACL_UNUSED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(out_desc);
 
   NaClLog(LOG_ERROR, "NaClDescConnCapFdAcceptConn: not IMC\n");
   return -NACL_ABI_EINVAL;

--- a/src/trusted/desc/posix/nacl_desc_imc_bound_desc.c
+++ b/src/trusted/desc/posix/nacl_desc_imc_bound_desc.c
@@ -57,7 +57,7 @@ void NaClDescImcBoundDescDtor(struct NaClRefCount *vself) {
 
 int NaClDescImcBoundDescFstat(struct NaClDesc          *vself,
                               struct nacl_abi_stat     *statbuf) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
 
   memset(statbuf, 0, sizeof *statbuf);
   statbuf->nacl_abi_st_mode = NACL_ABI_S_IFBOUNDSOCK;

--- a/src/trusted/perf_counter/nacl_perf_counter_test.c
+++ b/src/trusted/perf_counter/nacl_perf_counter_test.c
@@ -35,8 +35,8 @@ struct perf_counter_test arr[] = {
 int main(int argc, char*argv[]) {
   int i = 0;
   int64_t res = 0;
-  UNREFERENCED_PARAMETER(argc);
-  UNREFERENCED_PARAMETER(argv);
+  NACL_UNUSED_PARAMETER(argc);
+  NACL_UNUSED_PARAMETER(argv);
   NaClLogModuleInit();
   NaClTimeInit();
 

--- a/src/trusted/platform_qualify/posix/nacl_dep_qualify.c
+++ b/src/trusted/platform_qualify/posix/nacl_dep_qualify.c
@@ -110,12 +110,12 @@ typedef int MachExceptionHandlerData;
 
 static void DisableMachExceptionHandler(
     MachExceptionHandlerData *saved_handlers) {
-  UNREFERENCED_PARAMETER(saved_handlers);
+  NACL_UNUSED_PARAMETER(saved_handlers);
 }
 
 static void EnableMachExceptionHandler(
     MachExceptionHandlerData *saved_handlers) {
-  UNREFERENCED_PARAMETER(saved_handlers);
+  NACL_UNUSED_PARAMETER(saved_handlers);
 }
 
 #endif

--- a/src/trusted/seccomp_bpf/seccomp_bpf.c
+++ b/src/trusted/seccomp_bpf/seccomp_bpf.c
@@ -65,8 +65,8 @@ static void NaClSeccompBpfSigsysHandler(int nr, siginfo_t *info,
   int n;
   char *filename;
   int fatal = 1;
-  UNREFERENCED_PARAMETER(nr);
-  UNREFERENCED_PARAMETER(info);
+  NACL_UNUSED_PARAMETER(nr);
+  NACL_UNUSED_PARAMETER(info);
 
   syscall = ctx->uc_mcontext.gregs[REG_SYSCALL];
   switch (syscall) {

--- a/src/trusted/service_runtime/arch/arm/nacl_app.c
+++ b/src/trusted/service_runtime/arch/arm/nacl_app.c
@@ -21,7 +21,7 @@
  * No segments:  (currently) no-op.
  */
 NaClErrorCode NaClAppPrepareToLaunch(struct NaClApp     *nap) {
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
 
   return LOAD_OK;
 }

--- a/src/trusted/service_runtime/arch/arm/nacl_switch_to_app_arm.c
+++ b/src/trusted/service_runtime/arch/arm/nacl_switch_to_app_arm.c
@@ -20,7 +20,7 @@ void NaClInitSwitchToApp(struct NaClApp *nap) {
    * We don't need anything here.  We might need it in future if e.g.
    * we start letting untrusted code use NEON extensions.
    */
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
 }
 
 NORETURN void NaClStartThreadInApp(struct NaClAppThread *natp,

--- a/src/trusted/service_runtime/arch/arm/nacl_tls.c
+++ b/src/trusted/service_runtime/arch/arm/nacl_tls.c
@@ -86,7 +86,7 @@ static int NaClThreadIdxAllocate(void) {
  * actually launches.
  */
 uint32_t NaClTlsAllocate(struct NaClAppThread *natp) {
-  UNREFERENCED_PARAMETER(natp);
+  NACL_UNUSED_PARAMETER(natp);
 
   return NaClThreadIdxAllocate();
 }

--- a/src/trusted/service_runtime/arch/arm/sel_addrspace_arm.c
+++ b/src/trusted/service_runtime/arch/arm/sel_addrspace_arm.c
@@ -20,7 +20,7 @@ NaClErrorCode NaClAllocateSpaceAslr(void **mem, size_t addrsp_size,
   int result;
   void *tmp_mem = (void *) NACL_TRAMPOLINE_START;
 
-  UNREFERENCED_PARAMETER(aslr_mode);
+  NACL_UNUSED_PARAMETER(aslr_mode);
   CHECK(NULL != mem);
 
   /*

--- a/src/trusted/service_runtime/arch/arm/sel_ldr_arm.c
+++ b/src/trusted/service_runtime/arch/arm/sel_ldr_arm.c
@@ -24,7 +24,7 @@ void  NaClPatchOneTrampoline(struct NaClApp *nap,
   size_t trampoline_size = ((uintptr_t) &NaCl_trampoline_seg_end
                             - (uintptr_t) &NaCl_trampoline_seg_code);
 
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
 
   CHECK(trampoline_size == NACL_SYSCALL_BLOCK_SIZE);
   memcpy((void *) target_addr, &NaCl_trampoline_seg_code,
@@ -53,5 +53,5 @@ void NaClFillTrampolineRegion(struct NaClApp *nap) {
 
 
 void  NaClLoadSpringboard(struct NaClApp  *nap) {
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
 }

--- a/src/trusted/service_runtime/arch/mips/nacl_app.c
+++ b/src/trusted/service_runtime/arch/mips/nacl_app.c
@@ -21,7 +21,7 @@
  * No segments:  (currently) no-op.
  */
 NaClErrorCode NaClAppPrepareToLaunch(struct NaClApp     *nap) {
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
 
   return LOAD_OK;
 }

--- a/src/trusted/service_runtime/arch/mips/nacl_switch_to_app_mips.c
+++ b/src/trusted/service_runtime/arch/mips/nacl_switch_to_app_mips.c
@@ -19,7 +19,7 @@ void NaClInitSwitchToApp(struct NaClApp *nap) {
  /*
   * We don't need anything here.
   */
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
 }
 
 NORETURN void NaClStartThreadInApp(struct NaClAppThread *natp,

--- a/src/trusted/service_runtime/arch/mips/nacl_tls.c
+++ b/src/trusted/service_runtime/arch/mips/nacl_tls.c
@@ -88,7 +88,7 @@ static int NaClThreadIdxAllocate(void) {
 uint32_t NaClTlsAllocate(struct NaClAppThread *natp) {
   int idx = NaClThreadIdxAllocate();
 
-  UNREFERENCED_PARAMETER(natp);
+  NACL_UNUSED_PARAMETER(natp);
 
   NaClLog(2, "NaClTlsAllocate: idx %d\n", idx);
   if (-1 == idx) {

--- a/src/trusted/service_runtime/arch/mips/sel_addrspace_mips.c
+++ b/src/trusted/service_runtime/arch/mips/sel_addrspace_mips.c
@@ -20,7 +20,7 @@ NaClErrorCode NaClAllocateSpaceAslr(void **mem, size_t addrsp_size,
   int result;
   void *tmp_mem = (void *) NACL_TRAMPOLINE_START;
 
-  UNREFERENCED_PARAMETER(aslr_mode);
+  NACL_UNUSED_PARAMETER(aslr_mode);
   CHECK(NULL != mem);
 
   /*

--- a/src/trusted/service_runtime/arch/mips/sel_ldr_mips.c
+++ b/src/trusted/service_runtime/arch/mips/sel_ldr_mips.c
@@ -34,7 +34,7 @@ void  NaClPatchOneTrampoline(struct NaClApp *nap,
   size_t tramp_size = ((uintptr_t) &NaCl_trampoline_seg_end
                        - (uintptr_t) &NaCl_trampoline_seg_code);
 
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
 
   /*
    * We copy trampoline code to buffer so that we can patch it with address
@@ -91,6 +91,6 @@ void NaClFillTrampolineRegion(struct NaClApp *nap) {
 }
 
 void  NaClLoadSpringboard(struct NaClApp  *nap) {
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
 }
 

--- a/src/trusted/service_runtime/arch/x86_32/nacl_tls_32.c
+++ b/src/trusted/service_runtime/arch/x86_32/nacl_tls_32.c
@@ -99,7 +99,7 @@ struct NaClAppThread *NaClTlsGetCurrentThread(void) {
  * the thread's identity.
  */
 void NaClTlsSetCurrentThread(struct NaClAppThread *natp) {
-  UNREFERENCED_PARAMETER(natp);
+  NACL_UNUSED_PARAMETER(natp);
 }
 
 #endif

--- a/src/trusted/service_runtime/arch/x86_64/nacl_app_64.c
+++ b/src/trusted/service_runtime/arch/x86_64/nacl_app_64.c
@@ -23,7 +23,7 @@
  * No segments: (currently) no-op.
  */
 NaClErrorCode NaClAppPrepareToLaunch(struct NaClApp     *nap) {
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
 
   return LOAD_OK;
 }

--- a/src/trusted/service_runtime/arch/x86_64/nacl_tls_64.c
+++ b/src/trusted/service_runtime/arch/x86_64/nacl_tls_64.c
@@ -105,7 +105,7 @@ static void NaClThreadIdxFree(uint32_t i) {
  * actually launches.
  */
 uint32_t NaClTlsAllocate(struct NaClAppThread *natp) {
-  UNREFERENCED_PARAMETER(natp);
+  NACL_UNUSED_PARAMETER(natp);
 
   return NaClThreadIdxAllocate();
 }

--- a/src/trusted/service_runtime/arch/x86_64/sel_ldr_x86_64.c
+++ b/src/trusted/service_runtime/arch/x86_64/sel_ldr_x86_64.c
@@ -147,5 +147,5 @@ void NaClLoadSpringboard(struct NaClApp  *nap) {
   /*
    * There is no springboard for x86-64.
    */
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
 }

--- a/src/trusted/service_runtime/generic/vm_hole.c
+++ b/src/trusted/service_runtime/generic/vm_hole.c
@@ -8,17 +8,17 @@
 
 
 void NaClVmHoleWaitToStartThread(struct NaClApp *nap) {
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
 }
 
 void NaClVmHoleThreadStackIsSafe(struct NaClApp *nap) {
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
 }
 
 void NaClVmHoleOpeningMu(struct NaClApp *nap) {
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
 }
 
 void NaClVmHoleClosingMu(struct NaClApp *nap) {
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
 }

--- a/src/trusted/service_runtime/include/sys/time.h
+++ b/src/trusted/service_runtime/include/sys/time.h
@@ -43,13 +43,13 @@ typedef long int  nacl_abi_clock_t;  /* to be deprecated */
  * as a 24 byte trusted array, which is incorrect. This alignment causes
  * the trusted array to be correctly considered 32 bytes in length.
  */
-#if defined(NACL_WINDOWS) && NACL_WINDOWS != 0
+#ifdef _MSC_VER
 __declspec(align(8))
 #endif
 struct nacl_abi_timeval {
   nacl_abi_time_t      nacl_abi_tv_sec;
   nacl_abi_suseconds_t nacl_abi_tv_usec;
-#if defined(NACL_WINDOWS) && NACL_WINDOWS != 0
+#ifdef _MSC_VER
 };
 #else
 } __attribute__((aligned(8)));

--- a/src/trusted/service_runtime/linux/r_debug.c
+++ b/src/trusted/service_runtime/linux/r_debug.c
@@ -32,8 +32,8 @@
 
 void NaClHandleRDebug(const char *switch_value, char *argv0) {
 #if NACL_ANDROID
-  UNREFERENCED_PARAMETER(switch_value);
-  UNREFERENCED_PARAMETER(argv0);
+  NACL_UNUSED_PARAMETER(switch_value);
+  NACL_UNUSED_PARAMETER(argv0);
 #else
   char *endp = NULL;
   uintptr_t r_debug_addr = strtoul(switch_value, &endp, 0);

--- a/src/trusted/service_runtime/mmap_unittest.cc
+++ b/src/trusted/service_runtime/mmap_unittest.cc
@@ -14,6 +14,8 @@
 #elif NACL_OSX
 # include <mach/mach.h>
 # include <mach/mach_vm.h>
+#elif NACL_WINDOWS
+# include <share.h>
 #endif
 
 #include "gtest/gtest.h"

--- a/src/trusted/service_runtime/nacl_copy.h
+++ b/src/trusted/service_runtime/nacl_copy.h
@@ -103,11 +103,11 @@ static INLINE void NaClCopyDropLock(struct NaClApp *nap) {
 #else
 
 static INLINE void NaClCopyTakeLock(struct NaClApp *nap) {
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
 }
 
 static INLINE void NaClCopyDropLock(struct NaClApp *nap) {
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
 }
 
 #endif

--- a/src/trusted/service_runtime/nacl_desc_effector_ldr.c
+++ b/src/trusted/service_runtime/nacl_desc_effector_ldr.c
@@ -95,9 +95,9 @@ static void NaClDescEffLdrUnmapMemory(struct NaClDescEffector  *vself,
 static void NaClDescEffLdrUnmapMemory(struct NaClDescEffector  *vself,
                                       uintptr_t                sysaddr,
                                       size_t                   nbytes) {
-  UNREFERENCED_PARAMETER(vself);
-  UNREFERENCED_PARAMETER(sysaddr);
-  UNREFERENCED_PARAMETER(nbytes);
+  NACL_UNUSED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(sysaddr);
+  NACL_UNUSED_PARAMETER(nbytes);
 }
 #endif  /* NACL_WINDOWS */
 

--- a/src/trusted/service_runtime/nacl_error_gio_test.c
+++ b/src/trusted/service_runtime/nacl_error_gio_test.c
@@ -37,14 +37,14 @@ static int TailGioCtor(struct TailGio *self) {
 }
 
 static void TailGioDtor(struct Gio *vself) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
   return;
 }
 
 static ssize_t TailGioRead(struct Gio *vself, void *buf, size_t count) {
-  UNREFERENCED_PARAMETER(vself);
-  UNREFERENCED_PARAMETER(buf);
-  UNREFERENCED_PARAMETER(count);
+  NACL_UNUSED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(buf);
+  NACL_UNUSED_PARAMETER(count);
   return 0;
 }
 
@@ -88,19 +88,19 @@ static ssize_t TailGioWrite(struct Gio *vself, void const *buf, size_t count) {
 static off_t TailGioSeek(struct Gio *vself,
                   off_t offset,
                   int whence) {
-  UNREFERENCED_PARAMETER(vself);
-  UNREFERENCED_PARAMETER(offset);
-  UNREFERENCED_PARAMETER(whence);
+  NACL_UNUSED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(offset);
+  NACL_UNUSED_PARAMETER(whence);
   return 0;
 }
 
 static int TailGioFlush(struct Gio *vself) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
   return 0;
 }
 
 static int TailGioClose(struct Gio *vself) {
-  UNREFERENCED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(vself);
   return 0;
 }
 

--- a/src/trusted/service_runtime/nacl_resource.c
+++ b/src/trusted/service_runtime/nacl_resource.c
@@ -148,8 +148,8 @@ static struct NaClDesc *NaClResourceNaClAppFileOpen(
     int mode,
     int allow_debug) {
   struct NaClDesc *rv = NULL;
-  UNREFERENCED_PARAMETER(vself);
-  UNREFERENCED_PARAMETER(allow_debug);
+  NACL_UNUSED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(allow_debug);
 
   if (0 == strcmp(resource_locator, NACL_RESOURCE_FILE_DEV_NULL)) {
     rv = NaClResourceNullFactory();

--- a/src/trusted/service_runtime/nacl_signal_common.c
+++ b/src/trusted/service_runtime/nacl_signal_common.c
@@ -297,13 +297,13 @@ void NaClSignalSetUpExceptionFrame(volatile struct NaClExceptionFrame *frame,
   frame->context_ptr = context_user_addr;
   frame->portable.frame_ptr = (uint32_t) regs->ebp;
 #elif NACL_ARCH(NACL_BUILD_ARCH) == NACL_x86 && NACL_BUILD_SUBARCH == 64
-  UNREFERENCED_PARAMETER(context_user_addr);
+  NACL_UNUSED_PARAMETER(context_user_addr);
   frame->portable.frame_ptr = (uint32_t) regs->rbp;
 #elif NACL_ARCH(NACL_BUILD_ARCH) == NACL_arm
-  UNREFERENCED_PARAMETER(context_user_addr);
+  NACL_UNUSED_PARAMETER(context_user_addr);
   frame->portable.frame_ptr = regs->r11;
 #elif NACL_ARCH(NACL_BUILD_ARCH) == NACL_mips
-  UNREFERENCED_PARAMETER(context_user_addr);
+  NACL_UNUSED_PARAMETER(context_user_addr);
   frame->portable.frame_ptr = regs->frame_ptr;
 #else
 # error Unsupported architecture

--- a/src/trusted/service_runtime/nacl_signal_unittest.c
+++ b/src/trusted/service_runtime/nacl_signal_unittest.c
@@ -67,7 +67,7 @@ void WINAPI Exec_RW(void *ptr) {
 
   PtrUnion_t ptrUnion;
 
-  UNREFERENCED_PARAMETER(ptr);
+  NACL_UNUSED_PARAMETER(ptr);
 
   /* Allocate a READ/WRITE page */
   page = Alloc1Page(PROT_READ | PROT_WRITE);
@@ -85,7 +85,7 @@ void WINAPI Exec_RW(void *ptr) {
 void WINAPI Write_RX(void *ptr) {
   void *page;
 
-  UNREFERENCED_PARAMETER(ptr);
+  NACL_UNUSED_PARAMETER(ptr);
   /* Allocate a READ/EXEC page */
   page = Alloc1Page(PROT_READ | PROT_EXEC);
 
@@ -103,7 +103,7 @@ void WINAPI Write_RX(void *ptr) {
 void WINAPI ReadWriteUnmapped(void *ptr) {
   int *page;
 
-  UNREFERENCED_PARAMETER(ptr);
+  NACL_UNUSED_PARAMETER(ptr);
 
   /* Allocate and free so we know it can't be valid. */
   page = (int *) Alloc1Page(PROT_READ | PROT_WRITE);
@@ -151,8 +151,8 @@ void Attempt(const char *str, void (WINAPI *start_fn)(void *), int sig) {
 
 void Handler(int signal_number, const struct NaClSignalContext *context,
              int is_untrusted) {
-  UNREFERENCED_PARAMETER(context);
-  UNREFERENCED_PARAMETER(is_untrusted);
+  NACL_UNUSED_PARAMETER(context);
+  NACL_UNUSED_PARAMETER(is_untrusted);
 
   g_SigFound = signal_number;
 
@@ -173,8 +173,8 @@ int main(int argc, const char *argv[]) {
   const int kAccessUnmappedPageSignal = SIGSEGV;
   const int kDivideByZeroSignal = SIGFPE;
 
-  UNREFERENCED_PARAMETER(argc);
-  UNREFERENCED_PARAMETER(argv);
+  NACL_UNUSED_PARAMETER(argc);
+  NACL_UNUSED_PARAMETER(argv);
 
   NaClLogModuleInit();
   NaClTimeInit();

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -69,7 +69,7 @@ void NaClAddSyscall(struct NaClApp *nap, uint32_t num,
 }
 
 int32_t NaClSysNull(struct NaClAppThread *natp) {
-  UNREFERENCED_PARAMETER(natp);
+  NACL_UNUSED_PARAMETER(natp);
   return 0;
 }
 
@@ -132,7 +132,7 @@ int NaClHighResolutionTimerEnabled(void) {
 
 int32_t NaClSysGetpid(struct NaClAppThread *natp) {
   int32_t pid;
-  UNREFERENCED_PARAMETER(natp);
+  NACL_UNUSED_PARAMETER(natp);
 
   if (NaClAclBypassChecks) {
     pid = GETPID();
@@ -287,7 +287,7 @@ int32_t NaClSysSecondTlsGet(struct NaClAppThread *natp) {
 int NaClSysThreadNice(struct NaClAppThread *natp,
                       const int            nice) {
   /* Note: implementation of nacl_thread_nice is OS dependent. */
-  UNREFERENCED_PARAMETER(natp);
+  NACL_UNUSED_PARAMETER(natp);
   return nacl_thread_nice(nice);
 }
 
@@ -696,7 +696,7 @@ cleanup:
 }
 
 int32_t NaClSysSchedYield(struct NaClAppThread *natp) {
-  UNREFERENCED_PARAMETER(natp);
+  NACL_UNUSED_PARAMETER(natp);
 
   NaClThreadYield();
   return 0;
@@ -922,7 +922,7 @@ int32_t NaClSysTestInfoLeak(struct NaClAppThread *natp) {
 
 #endif
 
-  UNREFERENCED_PARAMETER(natp);
+  NACL_UNUSED_PARAMETER(natp);
 
   return -NACL_ABI_ENOSYS;
 }
@@ -943,7 +943,7 @@ int32_t NaClSysTestCrash(struct NaClAppThread *natp, int crash_type) {
    * a SIGSEGV, because they'll see a SIGILL instead.
    */
   volatile int *volatile p = 0;
-  UNREFERENCED_PARAMETER(natp);
+  NACL_UNUSED_PARAMETER(natp);
 
   switch (crash_type) {
     case NACL_TEST_CRASH_MEMORY:

--- a/src/trusted/service_runtime/nacl_valgrind_hooks.c
+++ b/src/trusted/service_runtime/nacl_valgrind_hooks.c
@@ -7,15 +7,15 @@
 #include "native_client/src/trusted/service_runtime/nacl_valgrind_hooks.h"
 
 void NaClFileMappingForValgrind(size_t vma, size_t size, size_t file_offset) {
-  UNREFERENCED_PARAMETER(vma);
-  UNREFERENCED_PARAMETER(size);
-  UNREFERENCED_PARAMETER(file_offset);
+  NACL_UNUSED_PARAMETER(vma);
+  NACL_UNUSED_PARAMETER(size);
+  NACL_UNUSED_PARAMETER(file_offset);
 }
 
 void NaClFileNameForValgrind(const char* name) {
-  UNREFERENCED_PARAMETER(name);
+  NACL_UNUSED_PARAMETER(name);
 }
 
 void NaClSandboxMemoryStartForValgrind(uintptr_t mem_start) {
-  UNREFERENCED_PARAMETER(mem_start);
+  NACL_UNUSED_PARAMETER(mem_start);
 }

--- a/src/trusted/service_runtime/osx/crash_filter.c
+++ b/src/trusted/service_runtime/osx/crash_filter.c
@@ -61,7 +61,7 @@ int NaClMachThreadStateIsInUntrusted(x86_thread_state_t *state,
 
   uint16_t global_cs;
 
-  UNREFERENCED_PARAMETER(nacl_thread_index);
+  NACL_UNUSED_PARAMETER(nacl_thread_index);
 
   CHECK(state->tsh.flavor == x86_THREAD_STATE32);
 

--- a/src/trusted/service_runtime/osx/mach_exception_handler.c
+++ b/src/trusted/service_runtime/osx/mach_exception_handler.c
@@ -410,12 +410,12 @@ kern_return_t nacl_catch_exception_raise(
     exception_data_t code,
     mach_msg_type_number_t code_count) {
   /* MIG generated code expects this, but should never be called. */
-  UNREFERENCED_PARAMETER(exception_port);
-  UNREFERENCED_PARAMETER(thread);
-  UNREFERENCED_PARAMETER(task);
-  UNREFERENCED_PARAMETER(exception);
-  UNREFERENCED_PARAMETER(code);
-  UNREFERENCED_PARAMETER(code_count);
+  NACL_UNUSED_PARAMETER(exception_port);
+  NACL_UNUSED_PARAMETER(thread);
+  NACL_UNUSED_PARAMETER(task);
+  NACL_UNUSED_PARAMETER(exception);
+  NACL_UNUSED_PARAMETER(code);
+  NACL_UNUSED_PARAMETER(code_count);
   NaClLog(LOG_FATAL, "nacl_catch_exception_raise: "
                      "Unrequested message received.\n");
   return KERN_FAILURE;
@@ -432,15 +432,15 @@ kern_return_t nacl_catch_exception_raise_state(
     thread_state_t new_state,
     mach_msg_type_number_t *new_state_count) {
   /* MIG generated code expects this, but should never be called. */
-  UNREFERENCED_PARAMETER(exception_port);
-  UNREFERENCED_PARAMETER(exception);
-  UNREFERENCED_PARAMETER(code);
-  UNREFERENCED_PARAMETER(code_count);
-  UNREFERENCED_PARAMETER(flavor);
-  UNREFERENCED_PARAMETER(old_state);
-  UNREFERENCED_PARAMETER(old_state_count);
-  UNREFERENCED_PARAMETER(new_state);
-  UNREFERENCED_PARAMETER(new_state_count);
+  NACL_UNUSED_PARAMETER(exception_port);
+  NACL_UNUSED_PARAMETER(exception);
+  NACL_UNUSED_PARAMETER(code);
+  NACL_UNUSED_PARAMETER(code_count);
+  NACL_UNUSED_PARAMETER(flavor);
+  NACL_UNUSED_PARAMETER(old_state);
+  NACL_UNUSED_PARAMETER(old_state_count);
+  NACL_UNUSED_PARAMETER(new_state);
+  NACL_UNUSED_PARAMETER(new_state_count);
   NaClLog(LOG_FATAL, "nacl_catch_exception_raise_state: "
                      "Unrequested message received.\n");
   return KERN_FAILURE;

--- a/src/trusted/service_runtime/osx/mach_thread_map.h
+++ b/src/trusted/service_runtime/osx/mach_thread_map.h
@@ -55,13 +55,13 @@ void NaClClearMachThreadForThreadIndex(uint32_t nacl_thread_index);
 static INLINE void NaClSetCurrentMachThreadForThreadIndex(
     uint32_t nacl_thread_index) {
   /* No-op for x86-32. */
-  UNREFERENCED_PARAMETER(nacl_thread_index);
+  NACL_UNUSED_PARAMETER(nacl_thread_index);
 }
 
 static INLINE void NaClClearMachThreadForThreadIndex(
     uint32_t nacl_thread_index) {
   /* No-op for x86-32. */
-  UNREFERENCED_PARAMETER(nacl_thread_index);
+  NACL_UNUSED_PARAMETER(nacl_thread_index);
 }
 
 #endif

--- a/src/trusted/service_runtime/osx/nacl_ldt.c
+++ b/src/trusted/service_runtime/osx/nacl_ldt.c
@@ -211,7 +211,7 @@ void NaClLdtPrintSelector(uint16_t selector) {
   printf("  64-bit code %s\n", (entry.code_64_bit ? "yes" : "no"));
   printf("  op size %s\n", (entry.op_size_32 ? "32" : "16"));
 #else
-  UNREFERENCED_PARAMETER(selector);
+  NACL_UNUSED_PARAMETER(selector);
 #endif
 }
 

--- a/src/trusted/service_runtime/posix/sel_addrspace_posix.c
+++ b/src/trusted/service_runtime/posix/sel_addrspace_posix.c
@@ -33,7 +33,7 @@ int NaClFindPrereservedSandboxMemory(void **p, size_t num_bytes) {
 void NaClAddrSpaceBeforeAlloc(size_t untrusted_size) {
   struct rlimit lim;
 
-  UNREFERENCED_PARAMETER(untrusted_size);
+  NACL_UNUSED_PARAMETER(untrusted_size);
 
   if (getrlimit(RLIMIT_AS, &lim) < 0) {
     NaClLog(LOG_WARNING, "NaClAddrSpaceBeforeAlloc: getrlimit failed: %s",

--- a/src/trusted/service_runtime/sel_ldr-inl.h
+++ b/src/trusted/service_runtime/sel_ldr-inl.h
@@ -127,13 +127,13 @@ static INLINE uintptr_t NaClSysToUser(struct NaClApp  *nap,
  */
 static INLINE uintptr_t NaClUserToSysStackAddr(struct NaClApp *nap,
                                                uintptr_t      stackaddr) {
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
   return stackaddr;
 }
 
 static INLINE uintptr_t NaClSysToUserStackAddr(struct NaClApp *nap,
                                                uintptr_t      stackaddr) {
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
   return stackaddr;
 }
 
@@ -189,11 +189,11 @@ static INLINE uintptr_t NaClSandboxCodeAddr(struct NaClApp *nap,
 #  error "What kind of x86 are we on anyway?!?"
 # endif
 #elif NACL_ARCH(NACL_BUILD_ARCH) == NACL_arm
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
   addr &= ~NACL_CONTROL_FLOW_MASK;
   return addr;
 #elif NACL_ARCH(NACL_BUILD_ARCH) == NACL_mips
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
   return addr & NACL_CONTROL_FLOW_MASK;
 #else
 # error "What architecture are we on?!?"

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -459,7 +459,7 @@ void  NaClLoadTrampoline(struct NaClApp *nap, enum NaClAslrMode aslr_mode) {
     NaClLog(LOG_FATAL, "NaClMakePcrelThunk failed!\n");
   }
 #else
-  UNREFERENCED_PARAMETER(aslr_mode);
+  NACL_UNUSED_PARAMETER(aslr_mode);
 #endif
 #if NACL_ARCH(NACL_BUILD_ARCH) == NACL_x86 && NACL_BUILD_SUBARCH == 64
   if (!NaClMakeDispatchAddrs(nap)) {

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -755,8 +755,8 @@ void NaClHandleRDebug(const char *switch_value, char *argv0);
 void NaClHandleReservedAtZero(const char *switch_value);
 #else
 static INLINE void NaClHandleBootstrapArgs(int *argc_p, char ***argv_p) {
-  UNREFERENCED_PARAMETER(argc_p);
-  UNREFERENCED_PARAMETER(argv_p);
+  NACL_UNUSED_PARAMETER(argc_p);
+  NACL_UNUSED_PARAMETER(argv_p);
 }
 #endif
 

--- a/src/trusted/service_runtime/sel_main.c
+++ b/src/trusted/service_runtime/sel_main.c
@@ -61,7 +61,7 @@ void NaClSetEnableOuterSandboxFunc(void (*func)(void)) {
 
 static void VmentryPrinter(void           *state,
                     struct NaClVmmapEntry *vmep) {
-  UNREFERENCED_PARAMETER(state);
+  NACL_UNUSED_PARAMETER(state);
   printf("page num 0x%06x\n", (uint32_t)vmep->page_num);
   printf("num pages %d\n", (uint32_t)vmep->npages);
   printf("prot bits %x\n", vmep->prot);

--- a/src/trusted/service_runtime/sel_mem.c
+++ b/src/trusted/service_runtime/sel_mem.c
@@ -97,7 +97,7 @@ void  NaClVmmapEntryFree(struct NaClVmmapEntry *entry) {
  */
 void NaClVmentryPrint(void                  *state,
                       struct NaClVmmapEntry *vmep) {
-  UNREFERENCED_PARAMETER(state);
+  NACL_UNUSED_PARAMETER(state);
 
   printf("page num 0x%06x\n", (uint32_t)vmep->page_num);
   printf("num pages %d\n", (uint32_t)vmep->npages);

--- a/src/trusted/service_runtime/sys_memory.c
+++ b/src/trusted/service_runtime/sys_memory.c
@@ -218,7 +218,7 @@ int NaClSysCommonAddrRangeContainsExecutablePages(struct NaClApp *nap,
    * callers (as of this writing) does this, but we truncate it down
    * to an allocation boundary to be sure.
    */
-  UNREFERENCED_PARAMETER(length);
+  NACL_UNUSED_PARAMETER(length);
   usraddr = NaClTruncAllocPage(usraddr);
   return usraddr < nap->dynamic_text_end;
 }
@@ -1033,7 +1033,7 @@ static int32_t MunmapInternal(struct NaClApp *nap,
 #else
 static int32_t MunmapInternal(struct NaClApp *nap,
                               uintptr_t sysaddr, size_t length) {
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
   NaClLog(3, "MunmapInternal(0x%08"NACL_PRIxPTR", 0x%"NACL_PRIxS")\n",
           (uintptr_t) sysaddr, length);
   /*

--- a/src/trusted/service_runtime/thread_suspension_unwind.c
+++ b/src/trusted/service_runtime/thread_suspension_unwind.c
@@ -29,7 +29,7 @@ static void GetNaClSyscallSeg(struct NaClApp *nap,
     *nacl_syscall_seg_regs_saved = (uintptr_t) &NaClSyscallSegRegsSavedNoSSE;
   }
 #else
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
 
   *nacl_syscall_seg = (uintptr_t) &NaClSyscallSeg;
   *nacl_syscall_seg_regs_saved = (uintptr_t) &NaClSyscallSegRegsSaved;

--- a/src/trusted/service_runtime/win/debug_exception_handler.h
+++ b/src/trusted/service_runtime/win/debug_exception_handler.h
@@ -50,15 +50,15 @@ EXTERN_C_END
  */
 
 static INLINE int NaClDebugExceptionHandlerEnsureAttached(struct NaClApp *nap) {
-  UNREFERENCED_PARAMETER(nap);
+  NACL_UNUSED_PARAMETER(nap);
 
   return 1;
 }
 
 static INLINE void NaClDebugExceptionHandlerStandaloneHandleArgs(int argc,
                                                                  char **argv) {
-  UNREFERENCED_PARAMETER(argc);
-  UNREFERENCED_PARAMETER(argv);
+  NACL_UNUSED_PARAMETER(argc);
+  NACL_UNUSED_PARAMETER(argv);
 }
 
 #endif

--- a/src/trusted/service_runtime/win/nacl_signal_stack.c
+++ b/src/trusted/service_runtime/win/nacl_signal_stack.c
@@ -12,16 +12,16 @@
  * allocate one.  This makes signal handling in Windows unsafe.
  */
 int NaClSignalStackAllocate(void **result) {
-  UNREFERENCED_PARAMETER(result);
+  NACL_UNUSED_PARAMETER(result);
   return 1; /* Success */
 }
 
 void NaClSignalStackFree(void *stack) {
-  UNREFERENCED_PARAMETER(stack);
+  NACL_UNUSED_PARAMETER(stack);
 }
 
 void NaClSignalStackRegister(void *stack) {
-  UNREFERENCED_PARAMETER(stack);
+  NACL_UNUSED_PARAMETER(stack);
 }
 
 void NaClSignalStackUnregister(void) {

--- a/src/trusted/service_runtime/win/sel_addrspace_win.c
+++ b/src/trusted/service_runtime/win/sel_addrspace_win.c
@@ -62,5 +62,5 @@ int NaClFindPrereservedSandboxMemory(void **p, size_t num_bytes) {
  * Nothing to do here on Windows.
  */
 void NaClAddrSpaceBeforeAlloc(size_t untrusted_size) {
-  UNREFERENCED_PARAMETER(untrusted_size);
+  NACL_UNUSED_PARAMETER(untrusted_size);
 }

--- a/src/trusted/validator/driver/ncval.cc
+++ b/src/trusted/validator/driver/ncval.cc
@@ -203,8 +203,8 @@ Bool ProcessInstruction(
 Bool ProcessError(
     const uint8_t *begin, const uint8_t *end,
     uint32_t validation_info, void *user_data_ptr) {
-  UNREFERENCED_PARAMETER(begin);
-  UNREFERENCED_PARAMETER(end);
+  NACL_UNUSED_PARAMETER(begin);
+  NACL_UNUSED_PARAMETER(end);
   UserData &user_data = *reinterpret_cast<UserData *>(user_data_ptr);
 
   // We do the same thing as in ProcessInstruction(): If we are not disabling
@@ -295,7 +295,7 @@ class NcvalArmProblemReporter : public ProblemReporter {
   void ReportProblemMessage(nacl_arm_dec::Violation violation,
                             uint32_t vaddr,
                             const char* message) {
-    UNREFERENCED_PARAMETER(violation);
+    NACL_UNUSED_PARAMETER(violation);
     if (errors->size() < max_errors) {
       errors->push_back(Error(vaddr, message));
     } else if (errors->size() == max_errors) {

--- a/src/trusted/validator/validation_cache_test.cc
+++ b/src/trusted/validator/validation_cache_test.cc
@@ -105,7 +105,7 @@ void *MockCreateQuery(void *handle) {
 }
 
 void MockAddData(void *query, const unsigned char *data, size_t length) {
-  UNREFERENCED_PARAMETER(data);
+  NACL_UNUSED_PARAMETER(data);
   MockQuery *mquery = (MockQuery *) query;
   ASSERT_EQ(QUERY_MARKER, mquery->marker);
   EXPECT_EQ(QUERY_CREATED, mquery->state);
@@ -146,7 +146,7 @@ void MockDestroyQuery(void *query) {
 
 /* Hint that the validation should use the (fake) cache. */
 int MockCachingIsInexpensive(const struct NaClValidationMetadata *metadata) {
-  UNREFERENCED_PARAMETER(metadata);
+  NACL_UNUSED_PARAMETER(metadata);
   return 1;
 }
 

--- a/src/trusted/validator_arm/actual_vs_baseline.cc
+++ b/src/trusted/validator_arm/actual_vs_baseline.cc
@@ -78,8 +78,8 @@ void ActualVsBaselineTester::ProcessMatch() {
 bool ActualVsBaselineTester::ApplySanityChecks(
       nacl_arm_dec::Instruction inst,
       const NamedClassDecoder& decoder) {
-  UNREFERENCED_PARAMETER(inst);
-  UNREFERENCED_PARAMETER(decoder);
+  NACL_UNUSED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(decoder);
   EXPECT_TRUE(false) << "Sanity Checks shouldn't be applied!";
   return false;
 }

--- a/src/trusted/validator_arm/decoder_tester.cc
+++ b/src/trusted/validator_arm/decoder_tester.cc
@@ -29,8 +29,8 @@ DecoderTester::DecoderTester()
 bool DecoderTester::PassesParsePreconditions(
     nacl_arm_dec::Instruction inst,
     const NamedClassDecoder& decoder) {
-  UNREFERENCED_PARAMETER(inst);
-  UNREFERENCED_PARAMETER(decoder);
+  NACL_UNUSED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(decoder);
   return true;
 }
 

--- a/src/trusted/validator_arm/dgen_decoder.py
+++ b/src/trusted/validator_arm/dgen_decoder.py
@@ -172,7 +172,7 @@ DECODER_BASE_HEADER="""
 DECODER_BASE_DEF="""
 Register %(decoder_name)s::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // %(neutral_rep)s
   return %(method_exp)s;
 }
@@ -193,7 +193,7 @@ DECODER_CLEARS_BITS_HEADER="""
 DECODER_CLEARS_BITS_DEF="""
 bool %(decoder_name)s::
 clears_bits(Instruction inst, uint32_t clears_mask) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // %(neutral_rep)s
   return %(method_exp)s;
 }
@@ -216,7 +216,7 @@ DECODER_DEFS_HEADER="""
 DECODER_DEFS_DEF="""
 RegisterList %(decoder_name)s::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // %(neutral_rep)s
   return %(method_exp)s;
 }
@@ -274,7 +274,7 @@ DECODER_IS_LITERAL_LOAD_HEADER="""
 DECODER_IS_LITERAL_LOAD_DEF="""
 bool %(decoder_name)s::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // %(neutral_rep)s
   return %(method_exp)s;
 }
@@ -297,7 +297,7 @@ DECODER_IS_LOAD_TP_HEADER="""
 DECODER_IS_LOAD_TP_DEF="""
 bool %(decoder_name)s::
 is_load_thread_address_pointer(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // %(neutral_rep)s
   return %(method_exp)s;
 }
@@ -318,7 +318,7 @@ DECODER_POOL_HEAD_HEADER="""
 DECODER_POOL_HEAD_DEF="""
 bool %(decoder_name)s::
 is_literal_pool_head(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // %(neutral_rep)s
   return %(method_exp)s;
 }
@@ -339,7 +339,7 @@ DECODER_RELATIVE_HEADER="""
 DECODER_RELATIVE_DEF="""
 bool %(decoder_name)s::
 is_relative_branch(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // %(neutral_rep)s
   return %(method_exp)s;
 }
@@ -360,7 +360,7 @@ DECODER_RELATIVE_OFFSET_HEADER="""
 DECODER_RELATIVE_OFFSET_DEF="""
 int32_t %(decoder_name)s::
 branch_target_offset(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // %(neutral_rep)s
   return %(method_exp)s;
 }
@@ -383,7 +383,7 @@ DECODER_SAFETY_HEADER="""
 DECODER_SAFETY_DEF_HEADER="""
 SafetyLevel %(decoder_name)s::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 """
 
 DECODER_SAFETY_DEF_CHECK="""
@@ -430,7 +430,7 @@ bool %(decoder_name)s::
 sets_Z_if_bits_clear(
       Instruction inst, Register test_register,
       uint32_t clears_mask) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // %(neutral_rep)s
   return %(method_exp)s;
 }
@@ -458,7 +458,7 @@ DECODER_SMALL_IMM_BASE_WB_DEF="""
 bool %(decoder_name)s::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // %(neutral_rep)s
   return %(method_exp)s;
 }
@@ -481,7 +481,7 @@ DECODER_TARGET_HEADER="""
 DECODER_TARGET_DEF="""
 Register %(decoder_name)s::
 branch_target_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // %(neutral_rep)s
   return %(method_exp)s;
 }
@@ -502,7 +502,7 @@ DECODER_USES_HEADER="""
 DECODER_USES_DEF="""
 RegisterList %(decoder_name)s::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // %(neutral_rep)s
   return %(method_exp)s;
 }

--- a/src/trusted/validator_arm/dgen_decoder_output.py
+++ b/src/trusted/validator_arm/dgen_decoder_output.py
@@ -288,7 +288,7 @@ def _generate_methods(decoder, values, out):
     # Add message to stop compilation warnings if this table
     # doesn't require subtables to select a class decoder.
     if not table.methods():
-      out.write("\n  UNREFERENCED_PARAMETER(inst);")
+      out.write("\n  NACL_UNUSED_PARAMETER(inst);")
 
     count = 0
     for row in opt_rows:

--- a/src/trusted/validator_arm/dgen_test_output.py
+++ b/src/trusted/validator_arm/dgen_test_output.py
@@ -616,7 +616,7 @@ def _generate_decoder_method_bodies(decoder, values, out):
     # Add message to stop compilation warnings if this table
     # doesn't require subtables to select a class decoder.
     if not table.methods():
-      out.write("  UNREFERENCED_PARAMETER(inst);")
+      out.write("  NACL_UNUSED_PARAMETER(inst);")
 
     count = 0
     for row in opt_rows:

--- a/src/trusted/validator_arm/gen/arm32_decode.cc
+++ b/src/trusted/validator_arm/gen/arm32_decode.cc
@@ -354,7 +354,7 @@ const ClassDecoder& Arm32DecoderState::decode_advanced_simd_data_processing_inst
 const ClassDecoder& Arm32DecoderState::decode_advanced_simd_element_or_structure_load_store_instructions(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00200000)  ==
           0x00200000 /* L(21)=1 */ &&
       (inst.Bits() & 0x00800000)  ==
@@ -502,7 +502,7 @@ const ClassDecoder& Arm32DecoderState::decode_advanced_simd_element_or_structure
 const ClassDecoder& Arm32DecoderState::decode_branch_branch_with_link_and_block_data_transfer(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x02500000)  ==
           0x00000000 /* op(25:20)=0xx0x0 */) {
     return Actual_STMDA_STMED_cccc100000w0nnnnrrrrrrrrrrrrrrrr_case_1_instance_;
@@ -780,7 +780,7 @@ const ClassDecoder& Arm32DecoderState::decode_data_processing_and_miscellaneous_
 const ClassDecoder& Arm32DecoderState::decode_data_processing_immediate(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x01F00000)  ==
           0x01100000 /* op(24:20)=10001 */ &&
       (inst.Bits() & 0x0000F000)  ==
@@ -876,7 +876,7 @@ const ClassDecoder& Arm32DecoderState::decode_data_processing_immediate(
 const ClassDecoder& Arm32DecoderState::decode_data_processing_register(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x01E00000)  ==
           0x01A00000 /* op1(24:20)=1101x */ &&
       (inst.Bits() & 0x00000F80)  !=
@@ -972,7 +972,7 @@ const ClassDecoder& Arm32DecoderState::decode_data_processing_register(
 const ClassDecoder& Arm32DecoderState::decode_data_processing_register_shifted_register(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x01900000)  ==
           0x01100000 /* op1(24:20)=10xx1 */ &&
       (inst.Bits() & 0x0000F000)  ==
@@ -1144,7 +1144,7 @@ const ClassDecoder& Arm32DecoderState::decode_extension_register_load_store_inst
 const ClassDecoder& Arm32DecoderState::decode_extra_load_store_instructions(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00000060)  ==
           0x00000020 /* op2(6:5)=01 */ &&
       (inst.Bits() & 0x00500000)  ==
@@ -1312,7 +1312,7 @@ const ClassDecoder& Arm32DecoderState::decode_floating_point_data_processing_ins
 const ClassDecoder& Arm32DecoderState::decode_halfword_multiply_and_multiply_accumulate(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00600000)  ==
           0x00000000 /* op1(22:21)=00 */) {
     return Actual_MLS_A1_cccc00000110ddddaaaammmm1001nnnn_case_1_instance_;
@@ -1355,7 +1355,7 @@ const ClassDecoder& Arm32DecoderState::decode_halfword_multiply_and_multiply_acc
 const ClassDecoder& Arm32DecoderState::decode_load_store_word_and_unsigned_byte(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x02000000)  ==
           0x00000000 /* A(25)=0 */ &&
       (inst.Bits() & 0x00500000)  ==
@@ -1927,7 +1927,7 @@ const ClassDecoder& Arm32DecoderState::decode_miscellaneous_instructions(
 const ClassDecoder& Arm32DecoderState::decode_msr_immediate_and_hints(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00400000)  ==
           0x00000000 /* op(22)=0 */ &&
       (inst.Bits() & 0x000F0000)  ==
@@ -2028,7 +2028,7 @@ const ClassDecoder& Arm32DecoderState::decode_msr_immediate_and_hints(
 const ClassDecoder& Arm32DecoderState::decode_multiply_and_multiply_accumulate(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00F00000)  ==
           0x00400000 /* op(23:20)=0100 */) {
     return Actual_SMLALBB_SMLALBT_SMLALTB_SMLALTT_cccc00010100hhhhllllmmmm1xx0nnnn_case_1_instance_;
@@ -2075,7 +2075,7 @@ const ClassDecoder& Arm32DecoderState::decode_multiply_and_multiply_accumulate(
 const ClassDecoder& Arm32DecoderState::decode_other_floating_point_data_processing_instructions(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x000F0000)  ==
           0x00010000 /* opc2(19:16)=0001 */ &&
       (inst.Bits() & 0x00000040)  ==
@@ -2152,7 +2152,7 @@ const ClassDecoder& Arm32DecoderState::decode_other_floating_point_data_processi
 const ClassDecoder& Arm32DecoderState::decode_packing_unpacking_saturation_and_reversal(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00700000)  ==
           0x00000000 /* op1(22:20)=000 */ &&
       (inst.Bits() & 0x000000E0)  ==
@@ -2251,7 +2251,7 @@ const ClassDecoder& Arm32DecoderState::decode_packing_unpacking_saturation_and_r
 const ClassDecoder& Arm32DecoderState::decode_parallel_addition_and_subtraction_signed(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00300000)  ==
           0x00200000 /* op1(21:20)=10 */ &&
       (inst.Bits() & 0x000000E0)  ==
@@ -2319,7 +2319,7 @@ const ClassDecoder& Arm32DecoderState::decode_parallel_addition_and_subtraction_
 const ClassDecoder& Arm32DecoderState::decode_parallel_addition_and_subtraction_unsigned(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00300000)  ==
           0x00200000 /* op1(21:20)=10 */ &&
       (inst.Bits() & 0x000000E0)  ==
@@ -2387,7 +2387,7 @@ const ClassDecoder& Arm32DecoderState::decode_parallel_addition_and_subtraction_
 const ClassDecoder& Arm32DecoderState::decode_saturating_addition_and_subtraction(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00000F00)  ==
           0x00000000 /* $pattern(31:0)=xxxxxxxxxxxxxxxxxxxx0000xxxxxxxx */) {
     return Actual_PKH_cccc01101000nnnnddddiiiiit01mmmm_case_1_instance_;
@@ -2402,7 +2402,7 @@ const ClassDecoder& Arm32DecoderState::decode_saturating_addition_and_subtractio
 const ClassDecoder& Arm32DecoderState::decode_signed_multiply_signed_and_unsigned_divide(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00700000)  ==
           0x00000000 /* op1(22:20)=000 */ &&
       (inst.Bits() & 0x00000080)  ==
@@ -2475,7 +2475,7 @@ const ClassDecoder& Arm32DecoderState::decode_signed_multiply_signed_and_unsigne
 const ClassDecoder& Arm32DecoderState::decode_simd_dp_1imm(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00000D00)  ==
           0x00000900 /* cmode(11:8)=10x1 */) {
     return Actual_VBIC_immediate_1111001i1d000mmmddddcccc0q11mmmm_case_1_instance_;
@@ -2551,7 +2551,7 @@ const ClassDecoder& Arm32DecoderState::decode_simd_dp_1imm(
 const ClassDecoder& Arm32DecoderState::decode_simd_dp_2misc(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00030000)  ==
           0x00000000 /* A(17:16)=00 */ &&
       (inst.Bits() & 0x00000780)  ==
@@ -2712,7 +2712,7 @@ const ClassDecoder& Arm32DecoderState::decode_simd_dp_2misc(
 const ClassDecoder& Arm32DecoderState::decode_simd_dp_2scalar(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00000F00)  ==
           0x00000900 /* A(11:8)=1001 */) {
     return Actual_VMLA_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_1_instance_;
@@ -2770,7 +2770,7 @@ const ClassDecoder& Arm32DecoderState::decode_simd_dp_2scalar(
 const ClassDecoder& Arm32DecoderState::decode_simd_dp_2shift(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00000F00)  ==
           0x00000500 /* A(11:8)=0101 */ &&
       (inst.Bits() & 0x01000000)  ==
@@ -2849,7 +2849,7 @@ const ClassDecoder& Arm32DecoderState::decode_simd_dp_2shift(
 const ClassDecoder& Arm32DecoderState::decode_simd_dp_3diff(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00000F00)  ==
           0x00000C00 /* A(11:8)=1100 */) {
     return Actual_VABAL_A2_1111001u1dssnnnndddd0101n0m0mmmm_case_1_instance_;
@@ -2907,7 +2907,7 @@ const ClassDecoder& Arm32DecoderState::decode_simd_dp_3diff(
 const ClassDecoder& Arm32DecoderState::decode_simd_dp_3same(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00000F00)  ==
           0x00000100 /* A(11:8)=0001 */ &&
       (inst.Bits() & 0x00000010)  ==
@@ -3121,7 +3121,7 @@ const ClassDecoder& Arm32DecoderState::decode_simd_dp_3same(
 const ClassDecoder& Arm32DecoderState::decode_synchronization_primitives(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00F00000)  ==
           0x00A00000 /* op(23:20)=1010 */ &&
       (inst.Bits() & 0x00000F00)  ==
@@ -3184,7 +3184,7 @@ const ClassDecoder& Arm32DecoderState::decode_synchronization_primitives(
 const ClassDecoder& Arm32DecoderState::decode_transfer_between_arm_core_and_extension_register_8_16_and_32_bit(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00000100)  ==
           0x00000000 /* C(8)=0 */ &&
       (inst.Bits() & 0x00E00000)  ==
@@ -3262,7 +3262,7 @@ const ClassDecoder& Arm32DecoderState::decode_transfer_between_arm_core_and_exte
 const ClassDecoder& Arm32DecoderState::decode_transfer_between_arm_core_and_extension_registers_64_bit(
      const Instruction inst) const
 {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00000100)  ==
           0x00000000 /* C(8)=0 */ &&
       (inst.Bits() & 0x000000D0)  ==

--- a/src/trusted/validator_arm/gen/arm32_decode_actuals_1.cc
+++ b/src/trusted/validator_arm/gen/arm32_decode_actuals_1.cc
@@ -24,7 +24,7 @@ namespace nacl_arm_dec {
 
 RegisterList Actual_ADC_immediate_cccc0010101snnnnddddiiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -38,7 +38,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_ADC_immediate_cccc0010101snnnnddddiiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -59,7 +59,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_ADC_immediate_cccc0010101snnnnddddiiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -78,7 +78,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_ADC_register_cccc0000101snnnnddddiiiiitt0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -91,7 +91,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_ADC_register_cccc0000101snnnnddddiiiiitt0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -112,7 +112,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_ADC_register_cccc0000101snnnnddddiiiiitt0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -137,7 +137,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_ADC_register_shifted_register_cccc0000101snnnnddddssss0tt1mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -151,7 +151,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_ADC_register_shifted_register_cccc0000101snnnnddddssss0tt1mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -173,7 +173,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_ADC_register_shifted_register_cccc0000101snnnnddddssss0tt1mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -196,7 +196,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_ADD_immediate_cccc0010100snnnnddddiiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -210,7 +210,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_ADD_immediate_cccc0010100snnnnddddiiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -239,7 +239,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_ADD_immediate_cccc0010100snnnnddddiiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -254,7 +254,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_ADR_A1_cccc001010001111ddddiiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -262,7 +262,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_ADR_A1_cccc001010001111ddddiiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(15:12)=1111 => FORBIDDEN_OPERANDS
   if ((inst.Bits() & 0x0000F000)  ==
@@ -275,7 +275,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_ADR_A1_cccc001010001111ddddiiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -294,7 +294,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_ASR_immediate_cccc0001101s0000ddddiiiii100mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -307,7 +307,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_ASR_immediate_cccc0001101s0000ddddiiiii100mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -328,7 +328,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_ASR_immediate_cccc0001101s0000ddddiiiii100mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -350,7 +350,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_ASR_register_cccc0001101s0000ddddmmmm0101nnnn_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -364,7 +364,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_ASR_register_cccc0001101s0000ddddmmmm0101nnnn_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -383,7 +383,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_ASR_register_cccc0001101s0000ddddmmmm0101nnnn_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -402,7 +402,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_BFC_cccc0111110mmmmmddddlllll0011111_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -410,7 +410,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_BFC_cccc0111110mmmmmddddlllll0011111_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) => UNPREDICTABLE
@@ -428,7 +428,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_BFC_cccc0111110mmmmmddddlllll0011111_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -448,7 +448,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_BFI_cccc0111110mmmmmddddlllll001nnnn_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -456,7 +456,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_BFI_cccc0111110mmmmmddddlllll001nnnn_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(3:0) => DECODER_ERROR
@@ -479,7 +479,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_BFI_cccc0111110mmmmmddddlllll001nnnn_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(15:12)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -502,7 +502,7 @@ uses(Instruction inst) const {
 
 bool Actual_BIC_immediate_cccc0011110snnnnddddiiiiiiiiiiii_case_1::
 clears_bits(Instruction inst, uint32_t clears_mask) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // clears_bits: '(ARMExpandImm(inst(11:0)) &&
   //       clears_mask())  ==
   //          clears_mask()'
@@ -511,7 +511,7 @@ clears_bits(Instruction inst, uint32_t clears_mask) const {
 
 RegisterList Actual_BIC_immediate_cccc0011110snnnnddddiiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -525,7 +525,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_BIC_immediate_cccc0011110snnnnddddiiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -546,7 +546,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_BIC_immediate_cccc0011110snnnnddddiiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -565,14 +565,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_BKPT_cccc00010010iiiiiiiiiiii0111iiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 bool Actual_BKPT_cccc00010010iiiiiiiiiiii0111iiii_case_1::
 is_literal_pool_head(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_pool_head: 'LiteralPoolHeadConstant()  ==
   //          inst'
   return ((inst.Bits()) == (nacl_arm_dec::LiteralPoolHeadConstant()));
@@ -580,7 +580,7 @@ is_literal_pool_head(Instruction inst) const {
 
 SafetyLevel Actual_BKPT_cccc00010010iiiiiiiiiiii0111iiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(31:28)=~1110 => UNPREDICTABLE
   if ((inst.Bits() & 0xF0000000)  !=
@@ -597,7 +597,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_BKPT_cccc00010010iiiiiiiiiiii0111iiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -629,14 +629,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 RegisterList Actual_BLX_immediate_1111101hiiiiiiiiiiiiiiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_BLX_immediate_1111101hiiiiiiiiiiiiiiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -648,7 +648,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_BLX_immediate_1111101hiiiiiiiiiiiiiiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -664,7 +664,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_BLX_register_cccc000100101111111111110011mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{15, 14}'
   return RegisterList().
    Add(Register(15)).
@@ -673,7 +673,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_BLX_register_cccc000100101111111111110011mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(3:0)=1111 => FORBIDDEN_OPERANDS
   if ((inst.Bits() & 0x0000000F)  ==
@@ -686,14 +686,14 @@ safety(Instruction inst) const {
 
 Register Actual_BLX_register_cccc000100101111111111110011mmmm_case_1::
 branch_target_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // target: 'inst(3:0)'
   return Register((inst.Bits() & 0x0000000F));
 }
 
 RegisterList Actual_BLX_register_cccc000100101111111111110011mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -732,7 +732,7 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 RegisterList Actual_BL_BLX_immediate_cccc1011iiiiiiiiiiiiiiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{15, 14}'
   return RegisterList().
    Add(Register(15)).
@@ -741,14 +741,14 @@ defs(Instruction inst) const {
 
 bool Actual_BL_BLX_immediate_cccc1011iiiiiiiiiiiiiiiiiiiiiiii_case_1::
 is_relative_branch(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // relative: 'true'
   return true;
 }
 
 int32_t Actual_BL_BLX_immediate_cccc1011iiiiiiiiiiiiiiiiiiiiiiii_case_1::
 branch_target_offset(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // relative_offset: "SignExtend(inst(23:0):'00'(1:0), 32) + 8"
   return (((((((inst.Bits() & 0x00FFFFFF)) << 2) | (0 & 0x00000003))) & 0x02000000)
        ? ((((((inst.Bits() & 0x00FFFFFF)) << 2) | (0 & 0x00000003))) | 0xFC000000)
@@ -757,7 +757,7 @@ branch_target_offset(Instruction inst) const {
 
 SafetyLevel Actual_BL_BLX_immediate_cccc1011iiiiiiiiiiiiiiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => MAY_BE_SAFE
   if (true)
@@ -769,7 +769,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_BL_BLX_immediate_cccc1011iiiiiiiiiiiiiiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -806,7 +806,7 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 RegisterList Actual_B_cccc1010iiiiiiiiiiiiiiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -814,14 +814,14 @@ defs(Instruction inst) const {
 
 bool Actual_B_cccc1010iiiiiiiiiiiiiiiiiiiiiiii_case_1::
 is_relative_branch(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // relative: 'true'
   return true;
 }
 
 int32_t Actual_B_cccc1010iiiiiiiiiiiiiiiiiiiiiiii_case_1::
 branch_target_offset(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // relative_offset: "SignExtend(inst(23:0):'00'(1:0), 32) + 8"
   return (((((((inst.Bits() & 0x00FFFFFF)) << 2) | (0 & 0x00000003))) & 0x02000000)
        ? ((((((inst.Bits() & 0x00FFFFFF)) << 2) | (0 & 0x00000003))) | 0xFC000000)
@@ -830,7 +830,7 @@ branch_target_offset(Instruction inst) const {
 
 SafetyLevel Actual_B_cccc1010iiiiiiiiiiiiiiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => MAY_BE_SAFE
   if (true)
@@ -842,7 +842,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_B_cccc1010iiiiiiiiiiiiiiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -878,7 +878,7 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 RegisterList Actual_Bx_cccc000100101111111111110001mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -886,7 +886,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_Bx_cccc000100101111111111110001mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(3:0)=1111 => FORBIDDEN_OPERANDS
   if ((inst.Bits() & 0x0000000F)  ==
@@ -899,14 +899,14 @@ safety(Instruction inst) const {
 
 Register Actual_Bx_cccc000100101111111111110001mmmm_case_1::
 branch_target_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // target: 'inst(3:0)'
   return Register((inst.Bits() & 0x0000000F));
 }
 
 RegisterList Actual_Bx_cccc000100101111111111110001mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -945,7 +945,7 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 RegisterList Actual_CLZ_cccc000101101111dddd11110001mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -953,7 +953,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_CLZ_cccc000101101111dddd11110001mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -969,7 +969,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_CLZ_cccc000101101111dddd11110001mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -983,7 +983,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_CMN_immediate_cccc00110111nnnn0000iiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16}'
   return RegisterList().
    Add(Register(16));
@@ -991,7 +991,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_CMN_immediate_cccc00110111nnnn0000iiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -999,7 +999,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_CMN_immediate_cccc00110111nnnn0000iiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -1015,7 +1015,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_CMN_register_cccc00010111nnnn0000iiiiitt0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16
   //       if inst(20)
   //       else 32}'
@@ -1027,7 +1027,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_CMN_register_cccc00010111nnnn0000iiiiitt0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -1035,7 +1035,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_CMN_register_cccc00010111nnnn0000iiiiitt0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -1056,7 +1056,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_CMN_register_shifted_register_cccc00010111nnnn0000ssss0tt1mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16}'
   return RegisterList().
    Add(Register(16));
@@ -1064,7 +1064,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_CMN_register_shifted_register_cccc00010111nnnn0000ssss0tt1mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -1083,7 +1083,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_CMN_register_shifted_register_cccc00010111nnnn0000ssss0tt1mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -1104,14 +1104,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_CVT_between_half_precision_and_single_precision_111100111d11ss10dddd011p00m0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_CVT_between_half_precision_and_single_precision_111100111d11ss10dddd011p00m0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=~01 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  !=
@@ -1140,7 +1140,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_CVT_between_half_precision_and_single_precision_111100111d11ss10dddd011p00m0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -1169,14 +1169,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_DMB_1111010101111111111100000101xxxx_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_DMB_1111010101111111111100000101xxxx_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // not '1111'(3:0)  ==
   //          inst(3:0) ||
@@ -1210,7 +1210,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_DMB_1111010101111111111100000101xxxx_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -1224,14 +1224,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_ISB_1111010101111111111100000110xxxx_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_ISB_1111010101111111111100000110xxxx_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(3:0)=~1111 => FORBIDDEN_OPERANDS
   if ((inst.Bits() & 0x0000000F)  !=
@@ -1244,7 +1244,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_ISB_1111010101111111111100000110xxxx_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -1269,14 +1269,14 @@ uses(Instruction inst) const {
 
 Register Actual_LDMDA_LDMFA_cccc100000w1nnnnrrrrrrrrrrrrrrrr_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_LDMDA_LDMFA_cccc100000w1nnnnrrrrrrrrrrrrrrrr_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: 'Union({inst(19:16)
   //       if inst(21)=1
   //       else 32}, RegisterList(inst(15:0)))'
@@ -1289,7 +1289,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_LDMDA_LDMFA_cccc100000w1nnnnrrrrrrrrrrrrrrrr_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -1317,7 +1317,7 @@ safety(Instruction inst) const {
 bool Actual_LDMDA_LDMFA_cccc100000w1nnnnrrrrrrrrrrrrrrrr_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(21)=1'
   return (inst.Bits() & 0x00200000)  ==
           0x00200000;
@@ -1325,7 +1325,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_LDMDA_LDMFA_cccc100000w1nnnnrrrrrrrrrrrrrrrr_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -1375,14 +1375,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_LDRB_immediate_cccc010pu1w1nnnnttttiiiiiiiiiiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_LDRB_immediate_cccc010pu1w1nnnnttttiiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)
   //       if inst(24)=0 ||
   //       inst(21)=1
@@ -1399,7 +1399,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_LDRB_immediate_cccc010pu1w1nnnnttttiiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) => DECODER_ERROR
@@ -1437,7 +1437,7 @@ safety(Instruction inst) const {
 bool Actual_LDRB_immediate_cccc010pu1w1nnnnttttiiiiiiiiiiii_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(24)=0 ||
   //       inst(21)=1'
   return ((inst.Bits() & 0x01000000)  ==
@@ -1448,7 +1448,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_LDRB_immediate_cccc010pu1w1nnnnttttiiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -1486,14 +1486,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_LDRB_literal_cccc0101u1011111ttttiiiiiiiiiiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: '15'
   return Register(15);
 }
 
 RegisterList Actual_LDRB_literal_cccc0101u1011111ttttiiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -1501,14 +1501,14 @@ defs(Instruction inst) const {
 
 bool Actual_LDRB_literal_cccc0101u1011111ttttiiiiiiiiiiii_case_1::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: 'true'
   return true;
 }
 
 SafetyLevel Actual_LDRB_literal_cccc0101u1011111ttttiiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) => UNPREDICTABLE
@@ -1521,7 +1521,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_LDRB_literal_cccc0101u1011111ttttiiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -1578,14 +1578,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_LDRB_register_cccc011pu1w1nnnnttttiiiiitt0mmmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_LDRB_register_cccc011pu1w1nnnnttttiiiiitt0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)
   //       if inst(24)=0 ||
   //       inst(21)=1
@@ -1602,7 +1602,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_LDRB_register_cccc011pu1w1nnnnttttiiiiitt0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -1659,7 +1659,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_LDRB_register_cccc011pu1w1nnnnttttiiiiitt0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(19:16)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -1712,14 +1712,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_LDRD_immediate_cccc000pu1w0nnnnttttiiii1101iiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_LDRD_immediate_cccc000pu1w0nnnnttttiiii1101iiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(15:12) + 1, inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -1737,7 +1737,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_LDRD_immediate_cccc000pu1w0nnnnttttiiii1101iiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:16)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0x000F0000)  ==
@@ -1783,7 +1783,7 @@ safety(Instruction inst) const {
 bool Actual_LDRD_immediate_cccc000pu1w0nnnnttttiiii1101iiii_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(inst(24)=0) ||
   //       (inst(21)=1)'
   return (((inst.Bits() & 0x01000000)  ==
@@ -1794,7 +1794,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_LDRD_immediate_cccc000pu1w0nnnnttttiiii1101iiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -1833,14 +1833,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_LDRD_literal_cccc0001u1001111ttttiiii1101iiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: '15'
   return Register(15);
 }
 
 RegisterList Actual_LDRD_literal_cccc0001u1001111ttttiiii1101iiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(15:12) + 1}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -1849,14 +1849,14 @@ defs(Instruction inst) const {
 
 bool Actual_LDRD_literal_cccc0001u1001111ttttiiii1101iiii_case_1::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: 'true'
   return true;
 }
 
 SafetyLevel Actual_LDRD_literal_cccc0001u1001111ttttiiii1101iiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(15:12)(0)=1 => UNPREDICTABLE
   if ((((inst.Bits() & 0x0000F000) >> 12) & 0x00000001)  ==
@@ -1874,7 +1874,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_LDRD_literal_cccc0001u1001111ttttiiii1101iiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -1938,14 +1938,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_LDRD_register_cccc000pu0w0nnnntttt00001101mmmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_LDRD_register_cccc000pu0w0nnnntttt00001101mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(15:12) + 1, inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -1963,7 +1963,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_LDRD_register_cccc000pu0w0nnnntttt00001101mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(15:12)(0)=1 => UNPREDICTABLE
   if ((((inst.Bits() & 0x0000F000) >> 12) & 0x00000001)  ==
@@ -2034,7 +2034,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_LDRD_register_cccc000pu0w0nnnntttt00001101mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -2074,14 +2074,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_LDREXB_cccc00011101nnnntttt111110011111_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_LDREXB_cccc00011101nnnntttt111110011111_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -2089,7 +2089,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_LDREXB_cccc00011101nnnntttt111110011111_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -2105,7 +2105,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_LDREXB_cccc00011101nnnntttt111110011111_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -2145,14 +2145,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_LDREXD_cccc00011011nnnntttt111110011111_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_LDREXD_cccc00011011nnnntttt111110011111_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(15:12) + 1}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -2161,7 +2161,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_LDREXD_cccc00011011nnnntttt111110011111_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(15:12)(0)=1 ||
   //       14  ==
@@ -2180,7 +2180,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_LDREXD_cccc00011011nnnntttt111110011111_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -2231,14 +2231,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_LDRH_immediate_cccc000pu1w1nnnnttttiiii1011iiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_LDRH_immediate_cccc000pu1w1nnnnttttiiii1011iiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -2255,7 +2255,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_LDRH_immediate_cccc000pu1w1nnnnttttiiii1011iiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:16)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0x000F0000)  ==
@@ -2296,7 +2296,7 @@ safety(Instruction inst) const {
 bool Actual_LDRH_immediate_cccc000pu1w1nnnnttttiiii1011iiii_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(inst(24)=0) ||
   //       (inst(21)=1)'
   return (((inst.Bits() & 0x01000000)  ==
@@ -2307,7 +2307,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_LDRH_immediate_cccc000pu1w1nnnnttttiiii1011iiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -2349,14 +2349,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_LDRH_literal_cccc000pu1w11111ttttiiii1011iiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: '15'
   return Register(15);
 }
 
 RegisterList Actual_LDRH_literal_cccc000pu1w11111ttttiiii1011iiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -2364,14 +2364,14 @@ defs(Instruction inst) const {
 
 bool Actual_LDRH_literal_cccc000pu1w11111ttttiiii1011iiii_case_1::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: 'true'
   return true;
 }
 
 SafetyLevel Actual_LDRH_literal_cccc000pu1w11111ttttiiii1011iiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -2397,7 +2397,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_LDRH_literal_cccc000pu1w11111ttttiiii1011iiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -2454,14 +2454,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_LDRH_register_cccc000pu0w1nnnntttt00001011mmmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_LDRH_register_cccc000pu0w1nnnntttt00001011mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -2478,7 +2478,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_LDRH_register_cccc000pu0w1nnnntttt00001011mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -2535,7 +2535,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_LDRH_register_cccc000pu0w1nnnntttt00001011mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -2596,14 +2596,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_LDR_immediate_cccc010pu0w1nnnnttttiiiiiiiiiiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_LDR_immediate_cccc010pu0w1nnnnttttiiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)
   //       if inst(24)=0 ||
   //       inst(21)=1
@@ -2620,7 +2620,7 @@ defs(Instruction inst) const {
 
 bool Actual_LDR_immediate_cccc010pu0w1nnnnttttiiiiiiiiiiii_case_1::
 is_load_thread_address_pointer(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_load_tp: '9  ==
   //          inst(19:16) &&
   //       inst(24)=1 &&
@@ -2646,7 +2646,7 @@ is_load_thread_address_pointer(Instruction inst) const {
 
 SafetyLevel Actual_LDR_immediate_cccc010pu0w1nnnnttttiiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) => DECODER_ERROR
@@ -2684,7 +2684,7 @@ safety(Instruction inst) const {
 bool Actual_LDR_immediate_cccc010pu0w1nnnnttttiiiiiiiiiiii_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(24)=0 ||
   //       inst(21)=1'
   return ((inst.Bits() & 0x01000000)  ==
@@ -2695,7 +2695,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_LDR_immediate_cccc010pu0w1nnnnttttiiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -2733,14 +2733,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_LDR_literal_cccc0101u0011111ttttiiiiiiiiiiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: '15'
   return Register(15);
 }
 
 RegisterList Actual_LDR_literal_cccc0101u0011111ttttiiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -2748,14 +2748,14 @@ defs(Instruction inst) const {
 
 bool Actual_LDR_literal_cccc0101u0011111ttttiiiiiiiiiiii_case_1::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: 'true'
   return true;
 }
 
 SafetyLevel Actual_LDR_literal_cccc0101u0011111ttttiiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) => FORBIDDEN_OPERANDS
@@ -2768,7 +2768,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_LDR_literal_cccc0101u0011111ttttiiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -2825,14 +2825,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_LDR_register_cccc011pu0w1nnnnttttiiiiitt0mmmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_LDR_register_cccc011pu0w1nnnnttttiiiiitt0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)
   //       if inst(24)=0 ||
   //       inst(21)=1
@@ -2849,7 +2849,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_LDR_register_cccc011pu0w1nnnnttttiiiiitt0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -2908,7 +2908,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_LDR_register_cccc011pu0w1nnnnttttiiiiitt0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(19:16)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -2948,7 +2948,7 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 RegisterList Actual_LSL_immediate_cccc0001101s0000ddddiiiii000mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -2961,7 +2961,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_LSL_immediate_cccc0001101s0000ddddiiiii000mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -2987,7 +2987,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_LSL_immediate_cccc0001101s0000ddddiiiii000mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -3006,7 +3006,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_MCR_cccc1110ooo0nnnnttttccccooo1mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
@@ -3035,7 +3035,7 @@ generate_diagnostics(ViolationSet violations,
 
 SafetyLevel Actual_MCR_cccc1110ooo0nnnnttttccccooo1mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -3047,7 +3047,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_MCR_cccc1110ooo0nnnnttttccccooo1mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3095,7 +3095,7 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 RegisterList Actual_MLA_A1_cccc0000001sddddaaaammmm1001nnnn_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16), 16
   //       if inst(20)=1
   //       else 32}'
@@ -3109,7 +3109,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_MLA_A1_cccc0000001sddddaaaammmm1001nnnn_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -3139,7 +3139,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_MLA_A1_cccc0000001sddddaaaammmm1001nnnn_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8), inst(15:12)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -3163,7 +3163,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_MLS_A1_cccc00000110ddddaaaammmm1001nnnn_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -3171,7 +3171,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_MLS_A1_cccc00000110ddddaaaammmm1001nnnn_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -3193,7 +3193,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_MLS_A1_cccc00000110ddddaaaammmm1001nnnn_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8), inst(15:12)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -3212,7 +3212,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_MOVE_scalar_to_ARM_core_register_cccc1110iii1nnnntttt1011nii10000_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -3220,7 +3220,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_MOVE_scalar_to_ARM_core_register_cccc1110iii1nnnntttt1011nii10000_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(23):inst(22:21):inst(6:5)(4:0)=10x00 ||
   //       inst(23):inst(22:21):inst(6:5)(4:0)=x0x10 => UNDEFINED
@@ -3251,7 +3251,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_MOVT_cccc00110100iiiiddddiiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -3276,7 +3276,7 @@ dynamic_code_replacement_sentinel(
 
 SafetyLevel Actual_MOVT_cccc00110100iiiiddddiiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(15:12)=1111 => UNPREDICTABLE
   if ((inst.Bits() & 0x0000F000)  ==
@@ -3289,7 +3289,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_MOVT_cccc00110100iiiiddddiiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3308,7 +3308,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_MOV_immediate_A1_cccc0011101s0000ddddiiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -3332,7 +3332,7 @@ dynamic_code_replacement_sentinel(
 
 SafetyLevel Actual_MOV_immediate_A1_cccc0011101s0000ddddiiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -3353,7 +3353,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_MOV_immediate_A1_cccc0011101s0000ddddiiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3368,7 +3368,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_MRS_cccc00010r001111dddd000000000000_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -3376,7 +3376,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_MRS_cccc00010r001111dddd000000000000_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(22)=1 => FORBIDDEN_OPERANDS
   if ((inst.Bits() & 0x00400000)  ==
@@ -3394,7 +3394,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_MRS_cccc00010r001111dddd000000000000_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3410,7 +3410,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_MSR_immediate_cccc00110010mm001111iiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16
   //       if inst(19:18)(1)=1
   //       else 32}'
@@ -3423,7 +3423,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_MSR_immediate_cccc00110010mm001111iiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=00 => DECODER_ERROR
   if ((inst.Bits() & 0x000C0000)  ==
@@ -3436,7 +3436,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_MSR_immediate_cccc00110010mm001111iiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3454,7 +3454,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_MSR_register_cccc00010010mm00111100000000nnnn_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16
   //       if inst(19:18)(1)=1
   //       else 32}'
@@ -3467,7 +3467,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_MSR_register_cccc00010010mm00111100000000nnnn_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=00 => UNPREDICTABLE
   if ((inst.Bits() & 0x000C0000)  ==
@@ -3485,7 +3485,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_MSR_register_cccc00010010mm00111100000000nnnn_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -3511,7 +3511,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_MUL_A1_cccc0000000sdddd0000mmmm1001nnnn_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16), 16
   //       if inst(20)=1
   //       else 32}'
@@ -3525,7 +3525,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_MUL_A1_cccc0000000sdddd0000mmmm1001nnnn_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -3552,7 +3552,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_MUL_A1_cccc0000000sdddd0000mmmm1001nnnn_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(11:8), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x00000F00) >> 8))).
@@ -3567,14 +3567,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_NOP_cccc0011001000001111000000000000_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_NOP_cccc0011001000001111000000000000_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -3582,7 +3582,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_NOP_cccc0011001000001111000000000000_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3596,14 +3596,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_NOT_IMPLEMENTED_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_NOT_IMPLEMENTED_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => NOT_IMPLEMENTED
   if (true)
@@ -3615,7 +3615,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_NOT_IMPLEMENTED_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3634,7 +3634,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_ORR_immediate_cccc0011100snnnnddddiiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -3658,7 +3658,7 @@ dynamic_code_replacement_sentinel(
 
 SafetyLevel Actual_ORR_immediate_cccc0011100snnnnddddiiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -3679,7 +3679,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_ORR_immediate_cccc0011100snnnnddddiiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -3699,7 +3699,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_PKH_cccc01101000nnnnddddiiiiit01mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -3707,7 +3707,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_PKH_cccc01101000nnnnddddiiiiit01mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -3726,7 +3726,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_PKH_cccc01101000nnnnddddiiiiit01mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -3746,21 +3746,21 @@ uses(Instruction inst) const {
 
 Register Actual_PLD_PLDW_immediate_11110101ur01nnnn1111iiiiiiiiiiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_PLD_PLDW_immediate_11110101ur01nnnn1111iiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 bool Actual_PLD_PLDW_immediate_11110101ur01nnnn1111iiiiiiiiiiii_case_1::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: '15  ==
   //          inst(19:16)'
   return ((((inst.Bits() & 0x000F0000) >> 16)) == (15));
@@ -3768,7 +3768,7 @@ is_literal_load(Instruction inst) const {
 
 SafetyLevel Actual_PLD_PLDW_immediate_11110101ur01nnnn1111iiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:16)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0x000F0000)  ==
@@ -3781,7 +3781,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_PLD_PLDW_immediate_11110101ur01nnnn1111iiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -3822,21 +3822,21 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_PLD_PLDW_register_11110111u001nnnn1111iiiiitt0mmmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_PLD_PLDW_register_11110111u001nnnn1111iiiiitt0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_PLD_PLDW_register_11110111u001nnnn1111iiiiitt0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(3:0) ||
@@ -3859,7 +3859,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_PLD_PLDW_register_11110111u001nnnn1111iiiiitt0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(19:16)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -3897,28 +3897,28 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_PLD_literal_11110101u10111111111iiiiiiiiiiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: '15'
   return Register(15);
 }
 
 RegisterList Actual_PLD_literal_11110101u10111111111iiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 bool Actual_PLD_literal_11110101u10111111111iiiiiiiiiiii_case_1::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: 'true'
   return true;
 }
 
 SafetyLevel Actual_PLD_literal_11110101u10111111111iiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => MAY_BE_SAFE
   if (true)
@@ -3930,7 +3930,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_PLD_literal_11110101u10111111111iiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -3968,21 +3968,21 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_PLI_immediate_literal_11110100u101nnnn1111iiiiiiiiiiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_PLI_immediate_literal_11110100u101nnnn1111iiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 bool Actual_PLI_immediate_literal_11110100u101nnnn1111iiiiiiiiiiii_case_1::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: '15  ==
   //          inst(19:16)'
   return ((((inst.Bits() & 0x000F0000) >> 16)) == (15));
@@ -3990,7 +3990,7 @@ is_literal_load(Instruction inst) const {
 
 SafetyLevel Actual_PLI_immediate_literal_11110100u101nnnn1111iiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => MAY_BE_SAFE
   if (true)
@@ -4002,7 +4002,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_PLI_immediate_literal_11110100u101nnnn1111iiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -4040,21 +4040,21 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_PLI_register_11110110u101nnnn1111iiiiitt0mmmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_PLI_register_11110110u101nnnn1111iiiiitt0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_PLI_register_11110110u101nnnn1111iiiiitt0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(3:0) => UNPREDICTABLE
@@ -4071,7 +4071,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_PLI_register_11110110u101nnnn1111iiiiitt0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(19:16)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -4111,7 +4111,7 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 RegisterList Actual_SBFX_cccc0111101wwwwwddddlllll101nnnn_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4119,7 +4119,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_SBFX_cccc0111101wwwwwddddlllll101nnnn_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4140,7 +4140,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_SBFX_cccc0111101wwwwwddddlllll101nnnn_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -4160,7 +4160,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_SDIV_cccc01110001dddd1111mmmm0001nnnn_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -4168,7 +4168,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_SDIV_cccc01110001dddd1111mmmm0001nnnn_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -4187,7 +4187,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_SDIV_cccc01110001dddd1111mmmm0001nnnn_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(11:8), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x00000F00) >> 8))).
@@ -4210,7 +4210,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_SMLAD_cccc01110000ddddaaaammmm00m1nnnn_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -4218,7 +4218,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_SMLAD_cccc01110000ddddaaaammmm00m1nnnn_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) => DECODER_ERROR
@@ -4242,7 +4242,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_SMLAD_cccc01110000ddddaaaammmm00m1nnnn_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8), inst(15:12)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -4268,7 +4268,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_SMLALBB_SMLALBT_SMLALTB_SMLALTT_cccc00010100hhhhllllmmmm1xx0nnnn_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -4277,7 +4277,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_SMLALBB_SMLALBT_SMLALTB_SMLALTT_cccc00010100hhhhllllmmmm1xx0nnnn_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4304,7 +4304,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_SMLALBB_SMLALBT_SMLALTB_SMLALTT_cccc00010100hhhhllllmmmm1xx0nnnn_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12), inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -4331,7 +4331,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_SMLALD_cccc01110100hhhhllllmmmm00m1nnnn_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16), inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -4340,7 +4340,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_SMLALD_cccc01110100hhhhllllmmmm00m1nnnn_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -4367,7 +4367,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_SMLALD_cccc01110100hhhhllllmmmm00m1nnnn_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(15:12), inst(11:8), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -4402,7 +4402,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_SMLAL_A1_cccc0000111shhhhllllmmmm1001nnnn_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16), 16
   //       if inst(20)=1
   //       else 32}'
@@ -4417,7 +4417,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_SMLAL_A1_cccc0000111shhhhllllmmmm1001nnnn_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4455,7 +4455,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_SMLAL_A1_cccc0000111shhhhllllmmmm1001nnnn_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12), inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -4478,7 +4478,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_SMULBB_SMULBT_SMULTB_SMULTT_cccc00010110dddd0000mmmm1xx0nnnn_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -4486,7 +4486,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_SMULBB_SMULBT_SMULTB_SMULTT_cccc00010110dddd0000mmmm1xx0nnnn_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -4505,7 +4505,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_SMULBB_SMULBT_SMULTB_SMULTT_cccc00010110dddd0000mmmm1xx0nnnn_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -4538,7 +4538,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_SMULL_A1_cccc0000110shhhhllllmmmm1001nnnn_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16), 16
   //       if inst(20)=1
   //       else 32}'
@@ -4553,7 +4553,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_SMULL_A1_cccc0000110shhhhllllmmmm1001nnnn_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4591,7 +4591,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_SMULL_A1_cccc0000110shhhhllllmmmm1001nnnn_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -4619,14 +4619,14 @@ uses(Instruction inst) const {
 
 Register Actual_STMDA_STMED_cccc100000w0nnnnrrrrrrrrrrrrrrrr_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_STMDA_STMED_cccc100000w0nnnnrrrrrrrrrrrrrrrr_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(21)=1
   //       else 32}'
@@ -4639,7 +4639,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_STMDA_STMED_cccc100000w0nnnnrrrrrrrrrrrrrrrr_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -4666,7 +4666,7 @@ safety(Instruction inst) const {
 bool Actual_STMDA_STMED_cccc100000w0nnnnrrrrrrrrrrrrrrrr_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(21)=1'
   return (inst.Bits() & 0x00200000)  ==
           0x00200000;
@@ -4674,7 +4674,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_STMDA_STMED_cccc100000w0nnnnrrrrrrrrrrrrrrrr_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: 'Union({inst(19:16)}, RegisterList(inst(15:0)))'
   return nacl_arm_dec::Union(RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))), nacl_arm_dec::RegisterList((inst.Bits() & 0x0000FFFF)));
@@ -4724,14 +4724,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_STRB_immediate_cccc010pu1w0nnnnttttiiiiiiiiiiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_STRB_immediate_cccc010pu1w0nnnnttttiiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(24)=0 ||
   //       inst(21)=1
@@ -4747,7 +4747,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_STRB_immediate_cccc010pu1w0nnnnttttiiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -4783,7 +4783,7 @@ safety(Instruction inst) const {
 bool Actual_STRB_immediate_cccc010pu1w0nnnnttttiiiiiiiiiiii_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(24)=0 ||
   //       inst(21)=1'
   return ((inst.Bits() & 0x01000000)  ==
@@ -4794,7 +4794,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_STRB_immediate_cccc010pu1w0nnnnttttiiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -4852,14 +4852,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_STRB_register_cccc011pu1w0nnnnttttiiiiitt0mmmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_STRB_register_cccc011pu1w0nnnnttttiiiiitt0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(24)=0 ||
   //       inst(21)=1
@@ -4875,7 +4875,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_STRB_register_cccc011pu1w0nnnnttttiiiiitt0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -4932,7 +4932,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_STRB_register_cccc011pu1w0nnnnttttiiiiitt0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(19:16), inst(15:12)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -4987,14 +4987,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_STRD_immediate_cccc000pu1w0nnnnttttiiii1111iiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_STRD_immediate_cccc000pu1w0nnnnttttiiii1111iiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -5010,7 +5010,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_STRD_immediate_cccc000pu1w0nnnnttttiiii1111iiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(15:12)(0)=1 => UNPREDICTABLE
   if ((((inst.Bits() & 0x0000F000) >> 12) & 0x00000001)  ==
@@ -5054,7 +5054,7 @@ safety(Instruction inst) const {
 bool Actual_STRD_immediate_cccc000pu1w0nnnnttttiiii1111iiii_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(inst(24)=0) ||
   //       (inst(21)=1)'
   return (((inst.Bits() & 0x01000000)  ==
@@ -5065,7 +5065,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_STRD_immediate_cccc000pu1w0nnnnttttiiii1111iiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12), inst(15:12) + 1, inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -5127,14 +5127,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_STRD_register_cccc000pu0w0nnnntttt00001111mmmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_STRD_register_cccc000pu0w0nnnntttt00001111mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -5150,7 +5150,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_STRD_register_cccc000pu0w0nnnntttt00001111mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(15:12)(0)=1 => UNPREDICTABLE
   if ((((inst.Bits() & 0x0000F000) >> 12) & 0x00000001)  ==
@@ -5215,7 +5215,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_STRD_register_cccc000pu0w0nnnntttt00001111mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12), inst(15:12) + 1, inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -5263,14 +5263,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_STREXB_cccc00011100nnnndddd11111001tttt_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_STREXB_cccc00011100nnnndddd11111001tttt_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5278,7 +5278,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_STREXB_cccc00011100nnnndddd11111001tttt_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -5305,7 +5305,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_STREXB_cccc00011100nnnndddd11111001tttt_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -5354,14 +5354,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_STREXD_cccc00011010nnnndddd11111001tttt_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_STREXD_cccc00011010nnnndddd11111001tttt_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5369,7 +5369,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_STREXD_cccc00011010nnnndddd11111001tttt_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -5402,7 +5402,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_STREXD_cccc00011010nnnndddd11111001tttt_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0), inst(3:0) + 1}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -5454,14 +5454,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_STRH_immediate_cccc000pu1w0nnnnttttiiii1011iiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_STRH_immediate_cccc000pu1w0nnnnttttiiii1011iiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -5477,7 +5477,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_STRH_immediate_cccc000pu1w0nnnnttttiiii1011iiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -5513,7 +5513,7 @@ safety(Instruction inst) const {
 bool Actual_STRH_immediate_cccc000pu1w0nnnnttttiiii1011iiii_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(inst(24)=0) ||
   //       (inst(21)=1)'
   return (((inst.Bits() & 0x01000000)  ==
@@ -5524,7 +5524,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_STRH_immediate_cccc000pu1w0nnnnttttiiii1011iiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12), inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -5582,14 +5582,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_STRH_register_cccc000pu0w0nnnntttt00001011mmmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_STRH_register_cccc000pu0w0nnnntttt00001011mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -5605,7 +5605,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_STRH_register_cccc000pu0w0nnnntttt00001011mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -5662,7 +5662,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_STRH_register_cccc000pu0w0nnnntttt00001011mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12), inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -5712,14 +5712,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_STR_immediate_cccc010pu0w0nnnnttttiiiiiiiiiiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_STR_immediate_cccc010pu0w0nnnnttttiiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(24)=0 ||
   //       inst(21)=1
@@ -5735,7 +5735,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_STR_immediate_cccc010pu0w0nnnnttttiiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -5766,7 +5766,7 @@ safety(Instruction inst) const {
 bool Actual_STR_immediate_cccc010pu0w0nnnnttttiiiiiiiiiiii_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(24)=0 ||
   //       inst(21)=1'
   return ((inst.Bits() & 0x01000000)  ==
@@ -5777,7 +5777,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_STR_immediate_cccc010pu0w0nnnnttttiiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -5833,14 +5833,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_STR_register_cccc011pd0w0nnnnttttiiiiitt0mmmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_STR_register_cccc011pd0w0nnnnttttiiiiitt0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(24)=0 ||
   //       inst(21)=1
@@ -5856,7 +5856,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_STR_register_cccc011pd0w0nnnnttttiiiiitt0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -5910,7 +5910,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_STR_register_cccc011pd0w0nnnnttttiiiiitt0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(19:16), inst(15:12)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -5946,14 +5946,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 RegisterList Actual_SWP_SWPB_cccc00010b00nnnntttt00001001tttt_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_SWP_SWPB_cccc00010b00nnnntttt00001001tttt_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => DEPRECATED
   if (true)
@@ -5965,7 +5965,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_SWP_SWPB_cccc00010b00nnnntttt00001001tttt_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5983,7 +5983,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_SXTAB16_cccc01101000nnnnddddrr000111mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5991,7 +5991,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_SXTAB16_cccc01101000nnnnddddrr000111mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:16)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0x000F0000)  ==
@@ -6012,7 +6012,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_SXTAB16_cccc01101000nnnnddddrr000111mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -6032,7 +6032,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_TST_immediate_cccc00110001nnnn0000iiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16}'
   return RegisterList().
    Add(Register(16));
@@ -6040,7 +6040,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_TST_immediate_cccc00110001nnnn0000iiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -6050,7 +6050,7 @@ bool Actual_TST_immediate_cccc00110001nnnn0000iiiiiiiiiiii_case_1::
 sets_Z_if_bits_clear(
       Instruction inst, Register test_register,
       uint32_t clears_mask) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // sets_Z_if_clear_bits: 'RegIndex(test_register())  ==
   //          inst(19:16) &&
   //       (ARMExpandImm_C(inst(11:0)) &&
@@ -6062,7 +6062,7 @@ sets_Z_if_bits_clear(
 
 RegisterList Actual_TST_immediate_cccc00110001nnnn0000iiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -6077,14 +6077,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_UDF_cccc01111111iiiiiiiiiiii1111iiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_UDF_cccc01111111iiiiiiiiiiii1111iiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // not IsUDFNaClSafe(inst) => FORBIDDEN_OPERANDS
   if (!(nacl_arm_dec::IsUDFNaClSafe(inst.Bits())))
@@ -6096,7 +6096,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_UDF_cccc01111111iiiiiiiiiiii1111iiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6110,14 +6110,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_Unnamed_11110100xx11xxxxxxxxxxxxxxxxxxxx_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_Unnamed_11110100xx11xxxxxxxxxxxxxxxxxxxx_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => UNPREDICTABLE
   if (true)
@@ -6129,7 +6129,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_Unnamed_11110100xx11xxxxxxxxxxxxxxxxxxxx_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6143,14 +6143,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_Unnamed_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_Unnamed_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => UNDEFINED
   if (true)
@@ -6162,7 +6162,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_Unnamed_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6177,14 +6177,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VABAL_A2_1111001u1dssnnnndddd0101n0m0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VABAL_A2_1111001u1dssnnnndddd0101n0m0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -6202,7 +6202,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VABAL_A2_1111001u1dssnnnndddd0101n0m0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6220,14 +6220,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VABA_1111001u0dssnnnndddd0111nqm1mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VABA_1111001u0dssnnnndddd0111nqm1mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -6254,7 +6254,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VABA_1111001u0dssnnnndddd0111nqm1mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }

--- a/src/trusted/validator_arm/gen/arm32_decode_actuals_2.cc
+++ b/src/trusted/validator_arm/gen/arm32_decode_actuals_2.cc
@@ -24,14 +24,14 @@ namespace nacl_arm_dec {
 
 RegisterList Actual_VABD_floating_point_111100110d1snnnndddd1101nqm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VABD_floating_point_111100110d1snnnndddd1101nqm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -58,7 +58,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VABD_floating_point_111100110d1snnnndddd1101nqm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -75,14 +75,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VABS_A1_111100111d11ss01dddd0f110qm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VABS_A1_111100111d11ss01dddd0f110qm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=11 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  ==
@@ -106,7 +106,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VABS_A1_111100111d11ss01dddd0f110qm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -123,14 +123,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VABS_A1_111100111d11ss01dddd0f110qm0mmmm_case_2::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VABS_A1_111100111d11ss01dddd0f110qm0mmmm_case_2::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -154,7 +154,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VABS_A1_111100111d11ss01dddd0f110qm0mmmm_case_2::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -168,14 +168,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VABS_cccc11101d110000dddd101s11m0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VABS_cccc11101d110000dddd101s11m0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => MAY_BE_SAFE
   if (true)
@@ -187,7 +187,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VABS_cccc11101d110000dddd101s11m0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -203,14 +203,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VADDHN_111100101dssnnnndddd0100n0m0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VADDHN_111100101dssnnnndddd0100n0m0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -231,7 +231,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VADDHN_111100101dssnnnndddd0100n0m0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -248,14 +248,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VADDL_VADDW_1111001u1dssnnnndddd000pn0m0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VADDL_VADDW_1111001u1dssnnnndddd000pn0m0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -279,7 +279,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VADDL_VADDW_1111001u1dssnnnndddd000pn0m0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -293,14 +293,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VADD_floating_point_cccc11100d11nnnndddd101sn0m0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VADD_floating_point_cccc11100d11nnnndddd101sn0m0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(31:28)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0xF0000000)  ==
@@ -313,7 +313,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VADD_floating_point_cccc11100d11nnnndddd101sn0m0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -330,14 +330,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VADD_integer_111100100dssnnnndddd1000nqm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VADD_integer_111100100dssnnnndddd1000nqm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -359,7 +359,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VADD_integer_111100100dssnnnndddd1000nqm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -376,14 +376,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VBIC_immediate_1111001i1d000mmmddddcccc0q11mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VBIC_immediate_1111001i1d000mmmddddcccc0q11mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(11:8)(0)=0 ||
   //       inst(11:8)(3:2)=11 => DECODER_ERROR
@@ -407,7 +407,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VBIC_immediate_1111001i1d000mmmddddcccc0q11mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -424,14 +424,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VCNT_111100111d11ss00dddd01010qm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VCNT_111100111d11ss00dddd01010qm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=~00 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  !=
@@ -455,7 +455,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VCNT_111100111d11ss00dddd01010qm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -470,14 +470,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VCVT_VCVTR_between_floating_point_and_integer_Floating_point_cccc11101d111ooodddd101sp1m0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VCVT_VCVTR_between_floating_point_and_integer_Floating_point_cccc11101d111ooodddd101sp1m0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(18:16)=~000 &&
   //       inst(18:16)=~10x => DECODER_ERROR
@@ -493,7 +493,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VCVT_VCVTR_between_floating_point_and_integer_Floating_point_cccc11101d111ooodddd101sp1m0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -511,14 +511,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VCVT_between_floating_point_and_fixed_point_1111001u1diiiiiidddd111p0qm1mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VCVT_between_floating_point_and_fixed_point_1111001u1diiiiiidddd111p0qm1mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:16)=000xxx => DECODER_ERROR
   if ((inst.Bits() & 0x00380000)  ==
@@ -547,7 +547,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VCVT_between_floating_point_and_fixed_point_1111001u1diiiiiidddd111p0qm1mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -564,14 +564,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VCVT_between_floating_point_and_fixed_point_Floating_point_cccc11101d111o1udddd101fx1i0iiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VCVT_between_floating_point_and_fixed_point_Floating_point_cccc11101d111o1udddd101fx1i0iiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 16
   //       if inst(7)=0
@@ -589,7 +589,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VCVT_between_floating_point_and_fixed_point_Floating_point_cccc11101d111o1udddd101fx1i0iiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -609,14 +609,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VDUP_ARM_core_register_cccc11101bq0ddddtttt1011d0e10000_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VDUP_ARM_core_register_cccc11101bq0ddddtttt1011d0e10000_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 14  !=
   //          inst(31:28) => DEPRECATED
@@ -647,7 +647,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VDUP_ARM_core_register_cccc11101bq0ddddtttt1011d0e10000_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -664,14 +664,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VDUP_scalar_111100111d11iiiidddd11000qm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VDUP_scalar_111100111d11iiiidddd11000qm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:16)=x000 => UNDEFINED
   if ((inst.Bits() & 0x00070000)  ==
@@ -692,7 +692,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VDUP_scalar_111100111d11iiiidddd11000qm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -711,14 +711,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VEXT_111100101d11nnnnddddiiiinqm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VEXT_111100101d11nnnnddddiiiinqm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -748,7 +748,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VEXT_111100101d11nnnnddddiiiinqm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -797,14 +797,14 @@ uses(Instruction inst) const {
 
 Register Actual_VLD1_multiple_single_elements_111101000d10nnnnddddttttssaammmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_VLD1_multiple_single_elements_111101000d10nnnnddddttttssaammmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -817,7 +817,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VLD1_multiple_single_elements_111101000d10nnnnddddttttssaammmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(11:8)=0111 &&
   //       inst(5:4)(1)=1 => UNDEFINED
@@ -892,7 +892,7 @@ safety(Instruction inst) const {
 bool Actual_VLD1_multiple_single_elements_111101000d10nnnnddddttttssaammmm_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -906,7 +906,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_VLD1_multiple_single_elements_111101000d10nnnnddddttttssaammmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -968,14 +968,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_VLD1_single_element_to_all_lanes_111101001d10nnnndddd1100sstammmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_VLD1_single_element_to_all_lanes_111101001d10nnnndddd1100sstammmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -988,7 +988,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VLD1_single_element_to_all_lanes_111101001d10nnnndddd1100sstammmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=11 ||
   //       (inst(7:6)=00 &&
@@ -1021,7 +1021,7 @@ safety(Instruction inst) const {
 bool Actual_VLD1_single_element_to_all_lanes_111101001d10nnnndddd1100sstammmm_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -1035,7 +1035,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_VLD1_single_element_to_all_lanes_111101001d10nnnndddd1100sstammmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -1100,14 +1100,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_VLD1_single_element_to_one_lane_111101001d10nnnnddddss00aaaammmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_VLD1_single_element_to_one_lane_111101001d10nnnnddddss00aaaammmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -1120,7 +1120,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VLD1_single_element_to_one_lane_111101001d10nnnnddddss00aaaammmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(11:10)=11 => UNDEFINED
   if ((inst.Bits() & 0x00000C00)  ==
@@ -1174,7 +1174,7 @@ safety(Instruction inst) const {
 bool Actual_VLD1_single_element_to_one_lane_111101001d10nnnnddddss00aaaammmm_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -1188,7 +1188,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_VLD1_single_element_to_one_lane_111101001d10nnnnddddss00aaaammmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -1257,14 +1257,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_VLD2_multiple_2_element_structures_111101000d10nnnnddddttttssaammmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_VLD2_multiple_2_element_structures_111101000d10nnnnddddttttssaammmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -1277,7 +1277,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VLD2_multiple_2_element_structures_111101000d10nnnnddddttttssaammmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=11 => UNDEFINED
   if ((inst.Bits() & 0x000000C0)  ==
@@ -1334,7 +1334,7 @@ safety(Instruction inst) const {
 bool Actual_VLD2_multiple_2_element_structures_111101000d10nnnnddddttttssaammmm_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -1348,7 +1348,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_VLD2_multiple_2_element_structures_111101000d10nnnnddddttttssaammmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -1408,14 +1408,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_VLD2_single_2_element_structure_to_all_lanes_111101001d10nnnndddd1101sstammmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_VLD2_single_2_element_structure_to_all_lanes_111101001d10nnnndddd1101sstammmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -1428,7 +1428,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VLD2_single_2_element_structure_to_all_lanes_111101001d10nnnndddd1101sstammmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=11 => UNDEFINED
   if ((inst.Bits() & 0x000000C0)  ==
@@ -1455,7 +1455,7 @@ safety(Instruction inst) const {
 bool Actual_VLD2_single_2_element_structure_to_all_lanes_111101001d10nnnndddd1101sstammmm_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -1469,7 +1469,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_VLD2_single_2_element_structure_to_all_lanes_111101001d10nnnndddd1101sstammmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -1539,14 +1539,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_VLD2_single_2_element_structure_to_one_lane_111101001d10nnnnddddss01aaaammmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_VLD2_single_2_element_structure_to_one_lane_111101001d10nnnnddddss01aaaammmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -1559,7 +1559,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VLD2_single_2_element_structure_to_one_lane_111101001d10nnnnddddss01aaaammmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(11:10)=11 => UNDEFINED
   if ((inst.Bits() & 0x00000C00)  ==
@@ -1614,7 +1614,7 @@ safety(Instruction inst) const {
 bool Actual_VLD2_single_2_element_structure_to_one_lane_111101001d10nnnnddddss01aaaammmm_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -1628,7 +1628,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_VLD2_single_2_element_structure_to_one_lane_111101001d10nnnnddddss01aaaammmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -1693,14 +1693,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_VLD3_multiple_3_element_structures_111101000d10nnnnddddttttssaammmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_VLD3_multiple_3_element_structures_111101000d10nnnnddddttttssaammmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -1713,7 +1713,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VLD3_multiple_3_element_structures_111101000d10nnnnddddttttssaammmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=11 ||
   //       inst(5:4)(1)=1 => UNDEFINED
@@ -1756,7 +1756,7 @@ safety(Instruction inst) const {
 bool Actual_VLD3_multiple_3_element_structures_111101000d10nnnnddddttttssaammmm_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -1770,7 +1770,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_VLD3_multiple_3_element_structures_111101000d10nnnnddddttttssaammmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -1833,14 +1833,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_VLD3_single_3_element_structure_to_all_lanes_111101001d10nnnndddd1110sstammmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_VLD3_single_3_element_structure_to_all_lanes_111101001d10nnnndddd1110sstammmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -1853,7 +1853,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VLD3_single_3_element_structure_to_all_lanes_111101001d10nnnndddd1110sstammmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=11 ||
   //       inst(4)=1 => UNDEFINED
@@ -1888,7 +1888,7 @@ safety(Instruction inst) const {
 bool Actual_VLD3_single_3_element_structure_to_all_lanes_111101001d10nnnndddd1110sstammmm_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -1902,7 +1902,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_VLD3_single_3_element_structure_to_all_lanes_111101001d10nnnndddd1110sstammmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -1986,14 +1986,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_VLD3_single_3_element_structure_to_one_lane_111101001d10nnnnddddss10aaaammmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_VLD3_single_3_element_structure_to_one_lane_111101001d10nnnnddddss10aaaammmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -2006,7 +2006,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VLD3_single_3_element_structure_to_one_lane_111101001d10nnnnddddss10aaaammmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(11:10)=11 => UNDEFINED
   if ((inst.Bits() & 0x00000C00)  ==
@@ -2102,7 +2102,7 @@ safety(Instruction inst) const {
 bool Actual_VLD3_single_3_element_structure_to_one_lane_111101001d10nnnnddddss10aaaammmm_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -2116,7 +2116,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_VLD3_single_3_element_structure_to_one_lane_111101001d10nnnnddddss10aaaammmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -2182,14 +2182,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_VLD4_multiple_4_element_structures_111101000d10nnnnddddttttssaammmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_VLD4_multiple_4_element_structures_111101000d10nnnnddddttttssaammmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -2202,7 +2202,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VLD4_multiple_4_element_structures_111101000d10nnnnddddttttssaammmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=11 => UNDEFINED
   if ((inst.Bits() & 0x000000C0)  ==
@@ -2247,7 +2247,7 @@ safety(Instruction inst) const {
 bool Actual_VLD4_multiple_4_element_structures_111101000d10nnnnddddttttssaammmm_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -2261,7 +2261,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_VLD4_multiple_4_element_structures_111101000d10nnnnddddttttssaammmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -2326,14 +2326,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_VLD4_single_4_element_structure_to_all_lanes_111101001d10nnnndddd1111sstammmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_VLD4_single_4_element_structure_to_all_lanes_111101001d10nnnndddd1111sstammmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -2346,7 +2346,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VLD4_single_4_element_structure_to_all_lanes_111101001d10nnnndddd1111sstammmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=11 &&
   //       inst(4)=0 => UNDEFINED
@@ -2386,7 +2386,7 @@ safety(Instruction inst) const {
 bool Actual_VLD4_single_4_element_structure_to_all_lanes_111101001d10nnnndddd1111sstammmm_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -2400,7 +2400,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_VLD4_single_4_element_structure_to_all_lanes_111101001d10nnnndddd1111sstammmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -2490,14 +2490,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_VLD4_single_4_element_structure_to_one_lane_111101001d10nnnnddddss11aaaammmm_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_VLD4_single_4_element_structure_to_one_lane_111101001d10nnnnddddss11aaaammmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -2510,7 +2510,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VLD4_single_4_element_structure_to_one_lane_111101001d10nnnnddddss11aaaammmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(11:10)=11 => UNDEFINED
   if ((inst.Bits() & 0x00000C00)  ==
@@ -2615,7 +2615,7 @@ safety(Instruction inst) const {
 bool Actual_VLD4_single_4_element_structure_to_one_lane_111101001d10nnnnddddss11aaaammmm_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -2629,7 +2629,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_VLD4_single_4_element_structure_to_one_lane_111101001d10nnnnddddss11aaaammmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -2695,14 +2695,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_VLDM_cccc110pudw1nnnndddd1010iiiiiiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_VLDM_cccc110pudw1nnnndddd1010iiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(21)=1
   //       else 32}'
@@ -2715,7 +2715,7 @@ defs(Instruction inst) const {
 
 bool Actual_VLDM_cccc110pudw1nnnndddd1010iiiiiiii_case_1::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: '15  ==
   //          inst(19:16)'
   return ((((inst.Bits() & 0x000F0000) >> 16)) == (15));
@@ -2723,7 +2723,7 @@ is_literal_load(Instruction inst) const {
 
 SafetyLevel Actual_VLDM_cccc110pudw1nnnndddd1010iiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(23)=0 &&
@@ -2789,7 +2789,7 @@ safety(Instruction inst) const {
 bool Actual_VLDM_cccc110pudw1nnnndddd1010iiiiiiii_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(21)=1'
   return (inst.Bits() & 0x00200000)  ==
           0x00200000;
@@ -2797,7 +2797,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_VLDM_cccc110pudw1nnnndddd1010iiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -2864,14 +2864,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_VLDM_cccc110pudw1nnnndddd1011iiiiiiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_VLDM_cccc110pudw1nnnndddd1011iiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(21)=1
   //       else 32}'
@@ -2884,7 +2884,7 @@ defs(Instruction inst) const {
 
 bool Actual_VLDM_cccc110pudw1nnnndddd1011iiiiiiii_case_1::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: '15  ==
   //          inst(19:16)'
   return ((((inst.Bits() & 0x000F0000) >> 16)) == (15));
@@ -2892,7 +2892,7 @@ is_literal_load(Instruction inst) const {
 
 SafetyLevel Actual_VLDM_cccc110pudw1nnnndddd1011iiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(23)=0 &&
@@ -2973,7 +2973,7 @@ safety(Instruction inst) const {
 bool Actual_VLDM_cccc110pudw1nnnndddd1011iiiiiiii_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(21)=1'
   return (inst.Bits() & 0x00200000)  ==
           0x00200000;
@@ -2981,7 +2981,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_VLDM_cccc110pudw1nnnndddd1011iiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -3018,21 +3018,21 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_VLDR_cccc1101ud01nnnndddd1010iiiiiiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_VLDR_cccc1101ud01nnnndddd1010iiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 bool Actual_VLDR_cccc1101ud01nnnndddd1010iiiiiiii_case_1::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: '15  ==
   //          inst(19:16)'
   return ((((inst.Bits() & 0x000F0000) >> 16)) == (15));
@@ -3040,7 +3040,7 @@ is_literal_load(Instruction inst) const {
 
 SafetyLevel Actual_VLDR_cccc1101ud01nnnndddd1010iiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -3048,7 +3048,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VLDR_cccc1101ud01nnnndddd1010iiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -3084,14 +3084,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 RegisterList Actual_VMLAL_by_scalar_A2_1111001u1dssnnnndddd0p10n1m0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VMLAL_by_scalar_A2_1111001u1dssnnnndddd0p10n1m0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -3112,7 +3112,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VMLAL_by_scalar_A2_1111001u1dssnnnndddd0p10n1m0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3131,14 +3131,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VMLA_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VMLA_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -3170,7 +3170,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VMLA_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3188,14 +3188,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VMLA_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_2::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VMLA_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_2::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -3224,7 +3224,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VMLA_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_2::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3239,14 +3239,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VMOVN_111100111d11ss10dddd001000m0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VMOVN_111100111d11ss10dddd001000m0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=11 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  ==
@@ -3264,7 +3264,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VMOVN_111100111d11ss10dddd001000m0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3280,14 +3280,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VMOV_ARM_core_register_to_scalar_cccc11100ii0ddddtttt1011dii10000_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VMOV_ARM_core_register_to_scalar_cccc11100ii0ddddtttt1011dii10000_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(22:21):inst(6:5)(3:0)=0x10 => UNDEFINED
   if (((((((inst.Bits() & 0x00600000) >> 21)) << 2) | ((inst.Bits() & 0x00000060) >> 5)) & 0x0000000B)  ==
@@ -3305,7 +3305,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VMOV_ARM_core_register_to_scalar_cccc11100ii0ddddtttt1011dii10000_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -3325,7 +3325,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VMOV_between_ARM_core_register_and_single_precision_register_cccc1110000onnnntttt1010n0010000_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)
   //       if inst(20)=1
   //       else 32}'
@@ -3338,7 +3338,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VMOV_between_ARM_core_register_and_single_precision_register_cccc1110000onnnntttt1010n0010000_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) => UNPREDICTABLE
@@ -3351,7 +3351,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VMOV_between_ARM_core_register_and_single_precision_register_cccc1110000onnnntttt1010n0010000_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12)
   //       if not inst(20)=1
   //       else 32}'
@@ -3381,7 +3381,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VMOV_between_two_ARM_core_registers_and_a_doubleword_extension_register_cccc1100010otttttttt101100m1mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)}
   //       if inst(20)=1
   //       else {}'
@@ -3395,7 +3395,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VMOV_between_two_ARM_core_registers_and_a_doubleword_extension_register_cccc1100010otttttttt101100m1mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -3419,7 +3419,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VMOV_between_two_ARM_core_registers_and_a_doubleword_extension_register_cccc1100010otttttttt101100m1mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}
   //       if inst(20)=1
   //       else {inst(15:12), inst(19:16)}'
@@ -3452,7 +3452,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VMOV_between_two_ARM_core_registers_and_two_single_precision_registers_cccc1100010otttttttt101000m1mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)}
   //       if inst(20)=1
   //       else {}'
@@ -3466,7 +3466,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VMOV_between_two_ARM_core_registers_and_two_single_precision_registers_cccc1100010otttttttt101000m1mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -3493,7 +3493,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VMOV_between_two_ARM_core_registers_and_two_single_precision_registers_cccc1100010otttttttt101000m1mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}
   //       if inst(20)=1
   //       else {inst(15:12), inst(19:16)}'
@@ -3520,14 +3520,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VMOV_immediate_A1_1111001m1d000mmmddddcccc0qp1mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VMOV_immediate_A1_1111001m1d000mmmddddcccc0qp1mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(5)=0 &&
   //       inst(11:8)(0)=1 &&
@@ -3562,7 +3562,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VMOV_immediate_A1_1111001m1d000mmmddddcccc0qp1mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3577,7 +3577,7 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VMRS_cccc111011110001tttt101000010000_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16
   //       if 15  ==
   //          inst(15:12)
@@ -3590,7 +3590,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VMRS_cccc111011110001tttt101000010000_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -3606,14 +3606,14 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VMSR_cccc111011100001tttt101000010000_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VMSR_cccc111011100001tttt101000010000_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) => UNPREDICTABLE
@@ -3626,7 +3626,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VMSR_cccc111011100001tttt101000010000_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -3644,14 +3644,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VMULL_polynomial_A2_1111001u1dssnnnndddd11p0n0m0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VMULL_polynomial_A2_1111001u1dssnnnndddd11p0n0m0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -3677,7 +3677,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VMULL_polynomial_A2_1111001u1dssnnnndddd11p0n0m0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3695,14 +3695,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VMUL_polynomial_A1_1111001u0dssnnnndddd1001nqm1mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VMUL_polynomial_A1_1111001u0dssnnnndddd1001nqm1mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -3729,7 +3729,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VMUL_polynomial_A1_1111001u0dssnnnndddd1001nqm1mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3747,14 +3747,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VMVN_immediate_1111001i1d000mmmddddcccc0q11mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VMVN_immediate_1111001i1d000mmmddddcccc0q11mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(11:8)(0)=1 &&
   //       inst(11:8)(3:2)=~11) ||
@@ -3781,7 +3781,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VMVN_immediate_1111001i1d000mmmddddcccc0q11mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3796,14 +3796,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VPADD_floating_point_111100110d0snnnndddd1101nqm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VPADD_floating_point_111100110d0snnnndddd1101nqm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)(0)=1 ||
   //       inst(6)=1 => UNDEFINED
@@ -3819,7 +3819,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VPADD_floating_point_111100110d0snnnndddd1101nqm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3834,14 +3834,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VPADD_integer_111100100dssnnnndddd1011n0m1mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VPADD_integer_111100100dssnnnndddd1011n0m1mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => UNDEFINED
   if ((inst.Bits() & 0x00300000)  ==
@@ -3859,7 +3859,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VPADD_integer_111100100dssnnnndddd1011n0m1mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3879,14 +3879,14 @@ uses(Instruction inst) const {
 
 Register Actual_VPOP_cccc11001d111101dddd1010iiiiiiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: '13'
   return Register(13);
 }
 
 RegisterList Actual_VPOP_cccc11001d111101dddd1010iiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{13}'
   return RegisterList().
    Add(Register(13));
@@ -3894,7 +3894,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VPOP_cccc11001d111101dddd1010iiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 0  ==
   //          inst(7:0) ||
@@ -3911,14 +3911,14 @@ safety(Instruction inst) const {
 bool Actual_VPOP_cccc11001d111101dddd1010iiiiiiii_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'true'
   return true;
 }
 
 RegisterList Actual_VPOP_cccc11001d111101dddd1010iiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{13}'
   return RegisterList().
    Add(Register(13));
@@ -3965,14 +3965,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_VPOP_cccc11001d111101dddd1011iiiiiiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: '13'
   return Register(13);
 }
 
 RegisterList Actual_VPOP_cccc11001d111101dddd1011iiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{13}'
   return RegisterList().
    Add(Register(13));
@@ -3980,7 +3980,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VPOP_cccc11001d111101dddd1011iiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 0  ==
   //          inst(7:0) / 2 ||
@@ -4012,14 +4012,14 @@ safety(Instruction inst) const {
 bool Actual_VPOP_cccc11001d111101dddd1011iiiiiiii_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'true'
   return true;
 }
 
 RegisterList Actual_VPOP_cccc11001d111101dddd1011iiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{13}'
   return RegisterList().
    Add(Register(13));
@@ -4055,14 +4055,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 RegisterList Actual_VQDMLAL_VQDMLSL_A1_111100101dssnnnndddd10p1n0m0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VQDMLAL_VQDMLSL_A1_111100101dssnnnndddd10p1n0m0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -4083,7 +4083,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VQDMLAL_VQDMLSL_A1_111100101dssnnnndddd10p1n0m0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4102,14 +4102,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VQDMULH_A1_111100100dssnnnndddd1011nqm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VQDMULH_A1_111100100dssnnnndddd1011nqm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -4139,7 +4139,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VQDMULH_A1_111100100dssnnnndddd1011nqm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4155,14 +4155,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VQMOVN_111100111d11ss10dddd0010ppm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VQMOVN_111100111d11ss10dddd0010ppm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=00 => DECODER_ERROR
   if ((inst.Bits() & 0x000000C0)  ==
@@ -4183,7 +4183,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VQMOVN_111100111d11ss10dddd0010ppm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4200,14 +4200,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VQRSHRN_1111001u1diiiiiidddd100p01m1mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VQRSHRN_1111001u1diiiiiidddd100p01m1mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:16)=000xxx => DECODER_ERROR
   if ((inst.Bits() & 0x00380000)  ==
@@ -4233,7 +4233,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VQRSHRN_1111001u1diiiiiidddd100p01m1mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4252,14 +4252,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VQSHL_VQSHLU_immediate_1111001u1diiiiiidddd011plqm1mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VQSHL_VQSHLU_immediate_1111001u1diiiiiidddd011plqm1mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7):inst(21:16)(6:0)=0000xxx => DECODER_ERROR
   if (((((((inst.Bits() & 0x00000080) >> 7)) << 6) | ((inst.Bits() & 0x003F0000) >> 16)) & 0x00000078)  ==
@@ -4291,7 +4291,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VQSHL_VQSHLU_immediate_1111001u1diiiiiidddd011plqm1mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4309,14 +4309,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VREV16_111100111d11ss00dddd000ppqm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VREV16_111100111d11ss00dddd000ppqm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 3  <
   //          inst(8:7) + inst(19:18) => UNDEFINED
@@ -4340,7 +4340,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VREV16_111100111d11ss00dddd000ppqm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4355,14 +4355,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VRSHRN_111100101diiiiiidddd100001m1mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VRSHRN_111100101diiiiiidddd100001m1mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:16)=000xxx => DECODER_ERROR
   if ((inst.Bits() & 0x00380000)  ==
@@ -4380,7 +4380,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VRSHRN_111100101diiiiiidddd100001m1mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4397,14 +4397,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VRSHR_1111001u1diiiiiidddd0010lqm1mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VRSHR_1111001u1diiiiiidddd0010lqm1mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7):inst(21:16)(6:0)=0000xxx => DECODER_ERROR
   if (((((((inst.Bits() & 0x00000080) >> 7)) << 6) | ((inst.Bits() & 0x003F0000) >> 16)) & 0x00000078)  ==
@@ -4428,7 +4428,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VRSHR_1111001u1diiiiiidddd0010lqm1mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4443,14 +4443,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VSHLL_A1_or_VMOVL_1111001u1diiiiiidddd101000m1mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VSHLL_A1_or_VMOVL_1111001u1diiiiiidddd101000m1mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:16)=000xxx => DECODER_ERROR
   if ((inst.Bits() & 0x00380000)  ==
@@ -4468,7 +4468,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VSHLL_A1_or_VMOVL_1111001u1diiiiiidddd101000m1mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4483,14 +4483,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VSHLL_A2_111100111d11ss10dddd001100m0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VSHLL_A2_111100111d11ss10dddd001100m0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=11 ||
   //       inst(15:12)(0)=1 => UNDEFINED
@@ -4506,7 +4506,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VSHLL_A2_111100111d11ss10dddd001100m0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4546,14 +4546,14 @@ uses(Instruction inst) const {
 
 Register Actual_VSTM_cccc110pudw0nnnndddd1010iiiiiiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_VSTM_cccc110pudw0nnnndddd1010iiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(21)=1
   //       else 32}'
@@ -4566,7 +4566,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VSTM_cccc110pudw0nnnndddd1010iiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(23)=0 &&
@@ -4637,7 +4637,7 @@ safety(Instruction inst) const {
 bool Actual_VSTM_cccc110pudw0nnnndddd1010iiiiiiii_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(21)=1'
   return (inst.Bits() & 0x00200000)  ==
           0x00200000;
@@ -4645,7 +4645,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_VSTM_cccc110pudw0nnnndddd1010iiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -4712,14 +4712,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_VSTM_cccc110pudw0nnnndddd1011iiiiiiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_VSTM_cccc110pudw0nnnndddd1011iiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(21)=1
   //       else 32}'
@@ -4732,7 +4732,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Actual_VSTM_cccc110pudw0nnnndddd1011iiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(23)=0 &&
@@ -4818,7 +4818,7 @@ safety(Instruction inst) const {
 bool Actual_VSTM_cccc110pudw0nnnndddd1011iiiiiiii_case_1::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(21)=1'
   return (inst.Bits() & 0x00200000)  ==
           0x00200000;
@@ -4826,7 +4826,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList Actual_VSTM_cccc110pudw0nnnndddd1011iiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -4863,21 +4863,21 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 Register Actual_VSTR_cccc1101ud00nnnndddd1010iiiiiiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList Actual_VSTR_cccc1101ud00nnnndddd1010iiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VSTR_cccc1101ud00nnnndddd1010iiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) => FORBIDDEN_OPERANDS
@@ -4890,7 +4890,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VSTR_cccc1101ud00nnnndddd1010iiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -4929,14 +4929,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 
 RegisterList Actual_VSWP_111100111d11ss10dddd00000qm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VSWP_111100111d11ss10dddd00000qm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(22):inst(15:12)  ==
   //          inst(5):inst(3:0) => UNKNOWN
@@ -4965,7 +4965,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VSWP_111100111d11ss10dddd00000qm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4980,14 +4980,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VTBL_VTBX_111100111d11nnnndddd10ccnpm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VTBL_VTBX_111100111d11nnnndddd10ccnpm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 32  <=
   //          inst(7):inst(19:16) + inst(9:8) + 1 => UNPREDICTABLE
@@ -5000,7 +5000,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VTBL_VTBX_111100111d11nnnndddd10ccnpm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5019,14 +5019,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VTRN_111100111d11ss10dddd00001qm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VTRN_111100111d11ss10dddd00001qm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(22):inst(15:12)  ==
   //          inst(5):inst(3:0) => UNKNOWN
@@ -5055,7 +5055,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VTRN_111100111d11ss10dddd00001qm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5076,14 +5076,14 @@ uses(Instruction inst) const {
 
 RegisterList Actual_VUZP_111100111d11ss10dddd00010qm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Actual_VUZP_111100111d11ss10dddd00010qm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(22):inst(15:12)  ==
   //          inst(5):inst(3:0) => UNKNOWN
@@ -5118,7 +5118,7 @@ safety(Instruction inst) const {
 
 RegisterList Actual_VUZP_111100111d11ss10dddd00010qm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }

--- a/src/trusted/validator_arm/gen/arm32_decode_baselines_1.cc
+++ b/src/trusted/validator_arm/gen/arm32_decode_baselines_1.cc
@@ -34,7 +34,7 @@ namespace nacl_arm_dec {
 //    uses: {Rn}}
 RegisterList ADC_immediate_cccc0010101snnnnddddiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -48,7 +48,7 @@ defs(Instruction inst) const {
 
 SafetyLevel ADC_immediate_cccc0010101snnnnddddiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -69,7 +69,7 @@ safety(Instruction inst) const {
 
 RegisterList ADC_immediate_cccc0010101snnnnddddiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -105,7 +105,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList ADC_register_cccc0000101snnnnddddiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -118,7 +118,7 @@ defs(Instruction inst) const {
 
 SafetyLevel ADC_register_cccc0000101snnnnddddiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -139,7 +139,7 @@ safety(Instruction inst) const {
 
 RegisterList ADC_register_cccc0000101snnnnddddiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -176,7 +176,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Rs}}
 RegisterList ADC_register_shifted_register_cccc0000101snnnnddddssss0tt1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -190,7 +190,7 @@ defs(Instruction inst) const {
 
 SafetyLevel ADC_register_shifted_register_cccc0000101snnnnddddssss0tt1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -212,7 +212,7 @@ safety(Instruction inst) const {
 
 RegisterList ADC_register_shifted_register_cccc0000101snnnnddddssss0tt1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -245,7 +245,7 @@ uses(Instruction inst) const {
 //    uses: {Rn}}
 RegisterList ADD_immediate_cccc0010100snnnnddddiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -259,7 +259,7 @@ defs(Instruction inst) const {
 
 SafetyLevel ADD_immediate_cccc0010100snnnnddddiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -288,7 +288,7 @@ safety(Instruction inst) const {
 
 RegisterList ADD_immediate_cccc0010100snnnnddddiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -324,7 +324,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList ADD_register_cccc0000100snnnnddddiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -337,7 +337,7 @@ defs(Instruction inst) const {
 
 SafetyLevel ADD_register_cccc0000100snnnnddddiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -358,7 +358,7 @@ safety(Instruction inst) const {
 
 RegisterList ADD_register_cccc0000100snnnnddddiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -395,7 +395,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Rs}}
 RegisterList ADD_register_shifted_register_cccc0000100snnnnddddssss0tt1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -409,7 +409,7 @@ defs(Instruction inst) const {
 
 SafetyLevel ADD_register_shifted_register_cccc0000100snnnnddddssss0tt1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -431,7 +431,7 @@ safety(Instruction inst) const {
 
 RegisterList ADD_register_shifted_register_cccc0000100snnnnddddssss0tt1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -454,7 +454,7 @@ uses(Instruction inst) const {
 //    uses: {Pc}}
 RegisterList ADR_A1_cccc001010001111ddddiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -462,7 +462,7 @@ defs(Instruction inst) const {
 
 SafetyLevel ADR_A1_cccc001010001111ddddiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(15:12)=1111 => FORBIDDEN_OPERANDS
   if ((inst.Bits() & 0x0000F000)  ==
@@ -475,7 +475,7 @@ safety(Instruction inst) const {
 
 RegisterList ADR_A1_cccc001010001111ddddiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -496,7 +496,7 @@ uses(Instruction inst) const {
 //    uses: {Pc}}
 RegisterList ADR_A2_cccc001001001111ddddiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -504,7 +504,7 @@ defs(Instruction inst) const {
 
 SafetyLevel ADR_A2_cccc001001001111ddddiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(15:12)=1111 => FORBIDDEN_OPERANDS
   if ((inst.Bits() & 0x0000F000)  ==
@@ -517,7 +517,7 @@ safety(Instruction inst) const {
 
 RegisterList ADR_A2_cccc001001001111ddddiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -546,7 +546,7 @@ uses(Instruction inst) const {
 //    uses: {Rn}}
 RegisterList AND_immediate_cccc0010000snnnnddddiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -560,7 +560,7 @@ defs(Instruction inst) const {
 
 SafetyLevel AND_immediate_cccc0010000snnnnddddiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -581,7 +581,7 @@ safety(Instruction inst) const {
 
 RegisterList AND_immediate_cccc0010000snnnnddddiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -617,7 +617,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList AND_register_cccc0000000snnnnddddiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -630,7 +630,7 @@ defs(Instruction inst) const {
 
 SafetyLevel AND_register_cccc0000000snnnnddddiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -651,7 +651,7 @@ safety(Instruction inst) const {
 
 RegisterList AND_register_cccc0000000snnnnddddiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -688,7 +688,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Rs}}
 RegisterList AND_register_shifted_register_cccc0000000snnnnddddssss0tt1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -702,7 +702,7 @@ defs(Instruction inst) const {
 
 SafetyLevel AND_register_shifted_register_cccc0000000snnnnddddssss0tt1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -724,7 +724,7 @@ safety(Instruction inst) const {
 
 RegisterList AND_register_shifted_register_cccc0000000snnnnddddssss0tt1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -760,7 +760,7 @@ uses(Instruction inst) const {
 //    uses: {Rm}}
 RegisterList ASR_immediate_cccc0001101s0000ddddiiiii100mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -773,7 +773,7 @@ defs(Instruction inst) const {
 
 SafetyLevel ASR_immediate_cccc0001101s0000ddddiiiii100mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -794,7 +794,7 @@ safety(Instruction inst) const {
 
 RegisterList ASR_immediate_cccc0001101s0000ddddiiiii100mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -821,7 +821,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList ASR_register_cccc0001101s0000ddddmmmm0101nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -835,7 +835,7 @@ defs(Instruction inst) const {
 
 SafetyLevel ASR_register_cccc0001101s0000ddddmmmm0101nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -854,7 +854,7 @@ safety(Instruction inst) const {
 
 RegisterList ASR_register_cccc0001101s0000ddddmmmm0101nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -880,7 +880,7 @@ uses(Instruction inst) const {
 //    uses: {Rd}}
 RegisterList BFC_cccc0111110mmmmmddddlllll0011111_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -888,7 +888,7 @@ defs(Instruction inst) const {
 
 SafetyLevel BFC_cccc0111110mmmmmddddlllll0011111_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) => UNPREDICTABLE
@@ -906,7 +906,7 @@ safety(Instruction inst) const {
 
 RegisterList BFC_cccc0111110mmmmmddddlllll0011111_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -934,7 +934,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rd}}
 RegisterList BFI_cccc0111110mmmmmddddlllll001nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -942,7 +942,7 @@ defs(Instruction inst) const {
 
 SafetyLevel BFI_cccc0111110mmmmmddddlllll001nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(3:0) => DECODER_ERROR
@@ -965,7 +965,7 @@ safety(Instruction inst) const {
 
 RegisterList BFI_cccc0111110mmmmmddddlllll001nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(15:12)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -998,7 +998,7 @@ uses(Instruction inst) const {
 //    uses: {Rn}}
 bool BIC_immediate_cccc0011110snnnnddddiiiiiiiiiiii_case_0::
 clears_bits(Instruction inst, uint32_t clears_mask) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // clears_bits: '(ARMExpandImm(inst(11:0)) &&
   //       clears_mask())  ==
   //          clears_mask()'
@@ -1007,7 +1007,7 @@ clears_bits(Instruction inst, uint32_t clears_mask) const {
 
 RegisterList BIC_immediate_cccc0011110snnnnddddiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -1021,7 +1021,7 @@ defs(Instruction inst) const {
 
 SafetyLevel BIC_immediate_cccc0011110snnnnddddiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -1042,7 +1042,7 @@ safety(Instruction inst) const {
 
 RegisterList BIC_immediate_cccc0011110snnnnddddiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -1078,7 +1078,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList BIC_register_cccc0001110snnnnddddiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -1091,7 +1091,7 @@ defs(Instruction inst) const {
 
 SafetyLevel BIC_register_cccc0001110snnnnddddiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -1112,7 +1112,7 @@ safety(Instruction inst) const {
 
 RegisterList BIC_register_cccc0001110snnnnddddiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -1149,7 +1149,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Rs}}
 RegisterList BIC_register_shifted_register_cccc0001110snnnnddddssss0tt1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -1163,7 +1163,7 @@ defs(Instruction inst) const {
 
 SafetyLevel BIC_register_shifted_register_cccc0001110snnnnddddssss0tt1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -1185,7 +1185,7 @@ safety(Instruction inst) const {
 
 RegisterList BIC_register_shifted_register_cccc0001110snnnnddddssss0tt1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -1213,14 +1213,14 @@ uses(Instruction inst) const {
 //    violations: [implied by 'is_literal_pool_head']}
 RegisterList BKPT_cccc00010010iiiiiiiiiiii0111iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 bool BKPT_cccc00010010iiiiiiiiiiii0111iiii_case_0::
 is_literal_pool_head(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_pool_head: 'LiteralPoolHeadConstant()  ==
   //          inst'
   return ((inst.Bits()) == (nacl_arm_dec::LiteralPoolHeadConstant()));
@@ -1228,7 +1228,7 @@ is_literal_pool_head(Instruction inst) const {
 
 SafetyLevel BKPT_cccc00010010iiiiiiiiiiii0111iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(31:28)=~1110 => UNPREDICTABLE
   if ((inst.Bits() & 0xF0000000)  !=
@@ -1245,7 +1245,7 @@ safety(Instruction inst) const {
 
 RegisterList BKPT_cccc00010010iiiiiiiiiiii0111iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -1279,14 +1279,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    uses: {}}
 RegisterList BLX_immediate_1111101hiiiiiiiiiiiiiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel BLX_immediate_1111101hiiiiiiiiiiiiiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -1298,7 +1298,7 @@ safety(Instruction inst) const {
 
 RegisterList BLX_immediate_1111101hiiiiiiiiiiiiiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -1320,7 +1320,7 @@ uses(Instruction inst) const {
 //    violations: [implied by 'target']}
 RegisterList BLX_register_cccc000100101111111111110011mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{15, 14}'
   return RegisterList().
    Add(Register(15)).
@@ -1329,7 +1329,7 @@ defs(Instruction inst) const {
 
 SafetyLevel BLX_register_cccc000100101111111111110011mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(3:0)=1111 => FORBIDDEN_OPERANDS
   if ((inst.Bits() & 0x0000000F)  ==
@@ -1342,14 +1342,14 @@ safety(Instruction inst) const {
 
 Register BLX_register_cccc000100101111111111110011mmmm_case_0::
 branch_target_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // target: 'inst(3:0)'
   return Register((inst.Bits() & 0x0000000F));
 }
 
 RegisterList BLX_register_cccc000100101111111111110011mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -1395,7 +1395,7 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'relative']}
 RegisterList BL_BLX_immediate_cccc1011iiiiiiiiiiiiiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{15, 14}'
   return RegisterList().
    Add(Register(15)).
@@ -1404,14 +1404,14 @@ defs(Instruction inst) const {
 
 bool BL_BLX_immediate_cccc1011iiiiiiiiiiiiiiiiiiiiiiii_case_0::
 is_relative_branch(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // relative: 'true'
   return true;
 }
 
 int32_t BL_BLX_immediate_cccc1011iiiiiiiiiiiiiiiiiiiiiiii_case_0::
 branch_target_offset(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // relative_offset: "SignExtend(inst(23:0):'00'(1:0), 32) + 8"
   return (((((((inst.Bits() & 0x00FFFFFF)) << 2) | (0 & 0x00000003))) & 0x02000000)
        ? ((((((inst.Bits() & 0x00FFFFFF)) << 2) | (0 & 0x00000003))) | 0xFC000000)
@@ -1420,7 +1420,7 @@ branch_target_offset(Instruction inst) const {
 
 SafetyLevel BL_BLX_immediate_cccc1011iiiiiiiiiiiiiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => MAY_BE_SAFE
   if (true)
@@ -1432,7 +1432,7 @@ safety(Instruction inst) const {
 
 RegisterList BL_BLX_immediate_cccc1011iiiiiiiiiiiiiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -1468,14 +1468,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    uses: {}}
 RegisterList BXJ_cccc000100101111111111110010mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel BXJ_cccc000100101111111111110010mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -1487,7 +1487,7 @@ safety(Instruction inst) const {
 
 RegisterList BXJ_cccc000100101111111111110010mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -1510,7 +1510,7 @@ uses(Instruction inst) const {
 //    violations: [implied by 'relative']}
 RegisterList B_cccc1010iiiiiiiiiiiiiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -1518,14 +1518,14 @@ defs(Instruction inst) const {
 
 bool B_cccc1010iiiiiiiiiiiiiiiiiiiiiiii_case_0::
 is_relative_branch(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // relative: 'true'
   return true;
 }
 
 int32_t B_cccc1010iiiiiiiiiiiiiiiiiiiiiiii_case_0::
 branch_target_offset(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // relative_offset: "SignExtend(inst(23:0):'00'(1:0), 32) + 8"
   return (((((((inst.Bits() & 0x00FFFFFF)) << 2) | (0 & 0x00000003))) & 0x02000000)
        ? ((((((inst.Bits() & 0x00FFFFFF)) << 2) | (0 & 0x00000003))) | 0xFC000000)
@@ -1534,7 +1534,7 @@ branch_target_offset(Instruction inst) const {
 
 SafetyLevel B_cccc1010iiiiiiiiiiiiiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => MAY_BE_SAFE
   if (true)
@@ -1546,7 +1546,7 @@ safety(Instruction inst) const {
 
 RegisterList B_cccc1010iiiiiiiiiiiiiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -1587,7 +1587,7 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'target']}
 RegisterList Bx_cccc000100101111111111110001mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -1595,7 +1595,7 @@ defs(Instruction inst) const {
 
 SafetyLevel Bx_cccc000100101111111111110001mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(3:0)=1111 => FORBIDDEN_OPERANDS
   if ((inst.Bits() & 0x0000000F)  ==
@@ -1608,14 +1608,14 @@ safety(Instruction inst) const {
 
 Register Bx_cccc000100101111111111110001mmmm_case_0::
 branch_target_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // target: 'inst(3:0)'
   return Register((inst.Bits() & 0x0000000F));
 }
 
 RegisterList Bx_cccc000100101111111111110001mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -1653,14 +1653,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    uses: {}}
 RegisterList CDP2_11111110iiiiiiiiiiiiiiiiiii0iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel CDP2_11111110iiiiiiiiiiiiiiiiiii0iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -1672,7 +1672,7 @@ safety(Instruction inst) const {
 
 RegisterList CDP2_11111110iiiiiiiiiiiiiiiiiii0iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -1687,14 +1687,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList CDP_cccc1110oooonnnnddddccccooo0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel CDP_cccc1110oooonnnnddddccccooo0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -1706,7 +1706,7 @@ safety(Instruction inst) const {
 
 RegisterList CDP_cccc1110oooonnnnddddccccooo0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -1722,14 +1722,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList CLREX_11110101011111111111000000011111_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel CLREX_11110101011111111111000000011111_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -1741,7 +1741,7 @@ safety(Instruction inst) const {
 
 RegisterList CLREX_11110101011111111111000000011111_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -1761,7 +1761,7 @@ uses(Instruction inst) const {
 //    uses: {Rm}}
 RegisterList CLZ_cccc000101101111dddd11110001mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -1769,7 +1769,7 @@ defs(Instruction inst) const {
 
 SafetyLevel CLZ_cccc000101101111dddd11110001mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -1785,7 +1785,7 @@ safety(Instruction inst) const {
 
 RegisterList CLZ_cccc000101101111dddd11110001mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -1805,7 +1805,7 @@ uses(Instruction inst) const {
 //    uses: {Rn}}
 RegisterList CMN_immediate_cccc00110111nnnn0000iiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16}'
   return RegisterList().
    Add(Register(16));
@@ -1813,7 +1813,7 @@ defs(Instruction inst) const {
 
 SafetyLevel CMN_immediate_cccc00110111nnnn0000iiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -1821,7 +1821,7 @@ safety(Instruction inst) const {
 
 RegisterList CMN_immediate_cccc00110111nnnn0000iiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -1852,7 +1852,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList CMN_register_cccc00010111nnnn0000iiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16
   //       if inst(20)
   //       else 32}'
@@ -1864,7 +1864,7 @@ defs(Instruction inst) const {
 
 SafetyLevel CMN_register_cccc00010111nnnn0000iiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -1872,7 +1872,7 @@ safety(Instruction inst) const {
 
 RegisterList CMN_register_cccc00010111nnnn0000iiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -1897,7 +1897,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Rs}}
 RegisterList CMN_register_shifted_register_cccc00010111nnnn0000ssss0tt1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16}'
   return RegisterList().
    Add(Register(16));
@@ -1905,7 +1905,7 @@ defs(Instruction inst) const {
 
 SafetyLevel CMN_register_shifted_register_cccc00010111nnnn0000ssss0tt1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -1924,7 +1924,7 @@ safety(Instruction inst) const {
 
 RegisterList CMN_register_shifted_register_cccc00010111nnnn0000ssss0tt1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -1946,7 +1946,7 @@ uses(Instruction inst) const {
 //    uses: {Rn}}
 RegisterList CMP_immediate_cccc00110101nnnn0000iiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16}'
   return RegisterList().
    Add(Register(16));
@@ -1954,7 +1954,7 @@ defs(Instruction inst) const {
 
 SafetyLevel CMP_immediate_cccc00110101nnnn0000iiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -1962,7 +1962,7 @@ safety(Instruction inst) const {
 
 RegisterList CMP_immediate_cccc00110101nnnn0000iiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -1993,7 +1993,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList CMP_register_cccc00010101nnnn0000iiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16
   //       if inst(20)
   //       else 32}'
@@ -2005,7 +2005,7 @@ defs(Instruction inst) const {
 
 SafetyLevel CMP_register_cccc00010101nnnn0000iiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -2013,7 +2013,7 @@ safety(Instruction inst) const {
 
 RegisterList CMP_register_cccc00010101nnnn0000iiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -2038,7 +2038,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Rs}}
 RegisterList CMP_register_shifted_register_cccc00010101nnnn0000ssss0tt1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16}'
   return RegisterList().
    Add(Register(16));
@@ -2046,7 +2046,7 @@ defs(Instruction inst) const {
 
 SafetyLevel CMP_register_shifted_register_cccc00010101nnnn0000ssss0tt1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -2065,7 +2065,7 @@ safety(Instruction inst) const {
 
 RegisterList CMP_register_shifted_register_cccc00010101nnnn0000ssss0tt1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -2084,14 +2084,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList CPS_111100010000iii00000000iii0iiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel CPS_111100010000iii00000000iii0iiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -2103,7 +2103,7 @@ safety(Instruction inst) const {
 
 RegisterList CPS_111100010000iii00000000iii0iiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -2134,14 +2134,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList CVT_between_half_precision_and_single_precision_111100111d11ss10dddd011p00m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel CVT_between_half_precision_and_single_precision_111100111d11ss10dddd011p00m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=~01 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  !=
@@ -2170,7 +2170,7 @@ safety(Instruction inst) const {
 
 RegisterList CVT_between_half_precision_and_single_precision_111100111d11ss10dddd011p00m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -2186,14 +2186,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList DBG_cccc001100100000111100001111iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel DBG_cccc001100100000111100001111iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -2205,7 +2205,7 @@ safety(Instruction inst) const {
 
 RegisterList DBG_cccc001100100000111100001111iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -2222,14 +2222,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList DMB_1111010101111111111100000101xxxx_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel DMB_1111010101111111111100000101xxxx_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // not '1111'(3:0)  ==
   //          inst(3:0) ||
@@ -2263,7 +2263,7 @@ safety(Instruction inst) const {
 
 RegisterList DMB_1111010101111111111100000101xxxx_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -2280,14 +2280,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList DSB_1111010101111111111100000100xxxx_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel DSB_1111010101111111111100000100xxxx_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // not '1111'(3:0)  ==
   //          inst(3:0) ||
@@ -2321,7 +2321,7 @@ safety(Instruction inst) const {
 
 RegisterList DSB_1111010101111111111100000100xxxx_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -2349,7 +2349,7 @@ uses(Instruction inst) const {
 //    uses: {Rn}}
 RegisterList EOR_immediate_cccc0010001snnnnddddiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -2363,7 +2363,7 @@ defs(Instruction inst) const {
 
 SafetyLevel EOR_immediate_cccc0010001snnnnddddiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -2384,7 +2384,7 @@ safety(Instruction inst) const {
 
 RegisterList EOR_immediate_cccc0010001snnnnddddiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -2420,7 +2420,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList EOR_register_cccc0000001snnnnddddiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -2433,7 +2433,7 @@ defs(Instruction inst) const {
 
 SafetyLevel EOR_register_cccc0000001snnnnddddiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -2454,7 +2454,7 @@ safety(Instruction inst) const {
 
 RegisterList EOR_register_cccc0000001snnnnddddiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -2491,7 +2491,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Rs}}
 RegisterList EOR_register_shifted_register_cccc0000001snnnnddddssss0tt1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -2505,7 +2505,7 @@ defs(Instruction inst) const {
 
 SafetyLevel EOR_register_shifted_register_cccc0000001snnnnddddssss0tt1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -2527,7 +2527,7 @@ safety(Instruction inst) const {
 
 RegisterList EOR_register_shifted_register_cccc0000001snnnnddddssss0tt1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -2546,14 +2546,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList ERET_cccc0001011000000000000001101110_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel ERET_cccc0001011000000000000001101110_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -2565,7 +2565,7 @@ safety(Instruction inst) const {
 
 RegisterList ERET_cccc0001011000000000000001101110_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -2579,14 +2579,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList FICTITIOUS_FIRST_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel FICTITIOUS_FIRST_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -2598,7 +2598,7 @@ safety(Instruction inst) const {
 
 RegisterList FICTITIOUS_FIRST_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -2614,14 +2614,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList HVC_cccc00010100iiiiiiiiiiii0111iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel HVC_cccc00010100iiiiiiiiiiii0111iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -2633,7 +2633,7 @@ safety(Instruction inst) const {
 
 RegisterList HVC_cccc00010100iiiiiiiiiiii0111iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -2650,14 +2650,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList ISB_1111010101111111111100000110xxxx_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel ISB_1111010101111111111100000110xxxx_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(3:0)=~1111 => FORBIDDEN_OPERANDS
   if ((inst.Bits() & 0x0000000F)  !=
@@ -2670,7 +2670,7 @@ safety(Instruction inst) const {
 
 RegisterList ISB_1111010101111111111100000110xxxx_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -2686,14 +2686,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList LDC2_immediate_1111110pudw1nnnniiiiiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel LDC2_immediate_1111110pudw1nnnniiiiiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -2705,7 +2705,7 @@ safety(Instruction inst) const {
 
 RegisterList LDC2_immediate_1111110pudw1nnnniiiiiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -2721,14 +2721,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList LDC2_literal_1111110pudw11111iiiiiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel LDC2_literal_1111110pudw11111iiiiiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -2740,7 +2740,7 @@ safety(Instruction inst) const {
 
 RegisterList LDC2_literal_1111110pudw11111iiiiiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -2755,14 +2755,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList LDC_immediate_cccc110pudw1nnnnddddcccciiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel LDC_immediate_cccc110pudw1nnnnddddcccciiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -2774,7 +2774,7 @@ safety(Instruction inst) const {
 
 RegisterList LDC_immediate_cccc110pudw1nnnnddddcccciiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -2789,14 +2789,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList LDC_literal_cccc110pudw11111ddddcccciiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel LDC_literal_cccc110pudw11111ddddcccciiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -2808,7 +2808,7 @@ safety(Instruction inst) const {
 
 RegisterList LDC_literal_cccc110pudw11111ddddcccciiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -2842,14 +2842,14 @@ uses(Instruction inst) const {
 //    wback: W(21)=1}
 Register LDMDA_LDMFA_cccc100000w1nnnnrrrrrrrrrrrrrrrr_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDMDA_LDMFA_cccc100000w1nnnnrrrrrrrrrrrrrrrr_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: 'Union({inst(19:16)
   //       if inst(21)=1
   //       else 32}, RegisterList(inst(15:0)))'
@@ -2862,7 +2862,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LDMDA_LDMFA_cccc100000w1nnnnrrrrrrrrrrrrrrrr_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -2890,7 +2890,7 @@ safety(Instruction inst) const {
 bool LDMDA_LDMFA_cccc100000w1nnnnrrrrrrrrrrrrrrrr_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(21)=1'
   return (inst.Bits() & 0x00200000)  ==
           0x00200000;
@@ -2898,7 +2898,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList LDMDA_LDMFA_cccc100000w1nnnnrrrrrrrrrrrrrrrr_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -2952,14 +2952,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    wback: W(21)=1}
 Register LDMDB_LDMEA_cccc100100w1nnnnrrrrrrrrrrrrrrrr_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDMDB_LDMEA_cccc100100w1nnnnrrrrrrrrrrrrrrrr_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: 'Union({inst(19:16)
   //       if inst(21)=1
   //       else 32}, RegisterList(inst(15:0)))'
@@ -2972,7 +2972,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LDMDB_LDMEA_cccc100100w1nnnnrrrrrrrrrrrrrrrr_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -3000,7 +3000,7 @@ safety(Instruction inst) const {
 bool LDMDB_LDMEA_cccc100100w1nnnnrrrrrrrrrrrrrrrr_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(21)=1'
   return (inst.Bits() & 0x00200000)  ==
           0x00200000;
@@ -3008,7 +3008,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList LDMDB_LDMEA_cccc100100w1nnnnrrrrrrrrrrrrrrrr_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -3062,14 +3062,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    wback: W(21)=1}
 Register LDMIB_LDMED_cccc100110w1nnnnrrrrrrrrrrrrrrrr_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDMIB_LDMED_cccc100110w1nnnnrrrrrrrrrrrrrrrr_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: 'Union({inst(19:16)
   //       if inst(21)=1
   //       else 32}, RegisterList(inst(15:0)))'
@@ -3082,7 +3082,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LDMIB_LDMED_cccc100110w1nnnnrrrrrrrrrrrrrrrr_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -3110,7 +3110,7 @@ safety(Instruction inst) const {
 bool LDMIB_LDMED_cccc100110w1nnnnrrrrrrrrrrrrrrrr_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(21)=1'
   return (inst.Bits() & 0x00200000)  ==
           0x00200000;
@@ -3118,7 +3118,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList LDMIB_LDMED_cccc100110w1nnnnrrrrrrrrrrrrrrrr_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -3172,14 +3172,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    wback: W(21)=1}
 Register LDM_LDMIA_LDMFD_cccc100010w1nnnnrrrrrrrrrrrrrrrr_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDM_LDMIA_LDMFD_cccc100010w1nnnnrrrrrrrrrrrrrrrr_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: 'Union({inst(19:16)
   //       if inst(21)=1
   //       else 32}, RegisterList(inst(15:0)))'
@@ -3192,7 +3192,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LDM_LDMIA_LDMFD_cccc100010w1nnnnrrrrrrrrrrrrrrrr_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -3220,7 +3220,7 @@ safety(Instruction inst) const {
 bool LDM_LDMIA_LDMFD_cccc100010w1nnnnrrrrrrrrrrrrrrrr_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(21)=1'
   return (inst.Bits() & 0x00200000)  ==
           0x00200000;
@@ -3228,7 +3228,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList LDM_LDMIA_LDMFD_cccc100010w1nnnnrrrrrrrrrrrrrrrr_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -3263,14 +3263,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    uses: {}}
 RegisterList LDM_User_registers_cccc100pu101nnnn0rrrrrrrrrrrrrrr_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel LDM_User_registers_cccc100pu101nnnn0rrrrrrrrrrrrrrr_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -3282,7 +3282,7 @@ safety(Instruction inst) const {
 
 RegisterList LDM_User_registers_cccc100pu101nnnn0rrrrrrrrrrrrrrr_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3297,14 +3297,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList LDM_exception_return_cccc100pu1w1nnnn1rrrrrrrrrrrrrrr_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel LDM_exception_return_cccc100pu1w1nnnn1rrrrrrrrrrrrrrr_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -3316,7 +3316,7 @@ safety(Instruction inst) const {
 
 RegisterList LDM_exception_return_cccc100pu1w1nnnn1rrrrrrrrrrrrrrr_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3331,14 +3331,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList LDRBT_A1_cccc0100u111nnnnttttiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel LDRBT_A1_cccc0100u111nnnnttttiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -3350,7 +3350,7 @@ safety(Instruction inst) const {
 
 RegisterList LDRBT_A1_cccc0100u111nnnnttttiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3365,14 +3365,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList LDRBT_A2_cccc0110u111nnnnttttiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel LDRBT_A2_cccc0110u111nnnnttttiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -3384,7 +3384,7 @@ safety(Instruction inst) const {
 
 RegisterList LDRBT_A2_cccc0110u111nnnnttttiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3432,14 +3432,14 @@ uses(Instruction inst) const {
 //         W(21)=1}
 Register LDRB_immediate_cccc010pu1w1nnnnttttiiiiiiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDRB_immediate_cccc010pu1w1nnnnttttiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)
   //       if inst(24)=0 ||
   //       inst(21)=1
@@ -3456,7 +3456,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LDRB_immediate_cccc010pu1w1nnnnttttiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) => DECODER_ERROR
@@ -3494,7 +3494,7 @@ safety(Instruction inst) const {
 bool LDRB_immediate_cccc010pu1w1nnnnttttiiiiiiiiiiii_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(24)=0 ||
   //       inst(21)=1'
   return ((inst.Bits() & 0x01000000)  ==
@@ -3505,7 +3505,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList LDRB_immediate_cccc010pu1w1nnnnttttiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -3552,14 +3552,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register LDRB_literal_cccc0101u1011111ttttiiiiiiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: '15'
   return Register(15);
 }
 
 RegisterList LDRB_literal_cccc0101u1011111ttttiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -3567,14 +3567,14 @@ defs(Instruction inst) const {
 
 bool LDRB_literal_cccc0101u1011111ttttiiiiiiiiiiii_case_0::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: 'true'
   return true;
 }
 
 SafetyLevel LDRB_literal_cccc0101u1011111ttttiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) => UNPREDICTABLE
@@ -3587,7 +3587,7 @@ safety(Instruction inst) const {
 
 RegisterList LDRB_literal_cccc0101u1011111ttttiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -3663,14 +3663,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //         W(21)=1}
 Register LDRB_register_cccc011pu1w1nnnnttttiiiiitt0mmmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDRB_register_cccc011pu1w1nnnnttttiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)
   //       if inst(24)=0 ||
   //       inst(21)=1
@@ -3687,7 +3687,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LDRB_register_cccc011pu1w1nnnnttttiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -3744,7 +3744,7 @@ safety(Instruction inst) const {
 
 RegisterList LDRB_register_cccc011pu1w1nnnnttttiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(19:16)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -3825,14 +3825,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //         (W(21)=1)}
 Register LDRD_immediate_cccc000pu1w0nnnnttttiiii1101iiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDRD_immediate_cccc000pu1w0nnnnttttiiii1101iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(15:12) + 1, inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -3850,7 +3850,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LDRD_immediate_cccc000pu1w0nnnnttttiiii1101iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:16)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0x000F0000)  ==
@@ -3896,7 +3896,7 @@ safety(Instruction inst) const {
 bool LDRD_immediate_cccc000pu1w0nnnnttttiiii1101iiii_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(inst(24)=0) ||
   //       (inst(21)=1)'
   return (((inst.Bits() & 0x01000000)  ==
@@ -3907,7 +3907,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList LDRD_immediate_cccc000pu1w0nnnnttttiiii1101iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -3966,14 +3966,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register LDRD_literal_cccc0001u1001111ttttiiii1101iiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: '15'
   return Register(15);
 }
 
 RegisterList LDRD_literal_cccc0001u1001111ttttiiii1101iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(15:12) + 1}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -3982,14 +3982,14 @@ defs(Instruction inst) const {
 
 bool LDRD_literal_cccc0001u1001111ttttiiii1101iiii_case_0::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: 'true'
   return true;
 }
 
 SafetyLevel LDRD_literal_cccc0001u1001111ttttiiii1101iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(15:12)(0)=1 => UNPREDICTABLE
   if ((((inst.Bits() & 0x0000F000) >> 12) & 0x00000001)  ==
@@ -4007,7 +4007,7 @@ safety(Instruction inst) const {
 
 RegisterList LDRD_literal_cccc0001u1001111ttttiiii1101iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -4090,14 +4090,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //         (W(21)=1)}
 Register LDRD_register_cccc000pu0w0nnnntttt00001101mmmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDRD_register_cccc000pu0w0nnnntttt00001101mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(15:12) + 1, inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -4115,7 +4115,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LDRD_register_cccc000pu0w0nnnntttt00001101mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(15:12)(0)=1 => UNPREDICTABLE
   if ((((inst.Bits() & 0x0000F000) >> 12) & 0x00000001)  ==
@@ -4186,7 +4186,7 @@ safety(Instruction inst) const {
 
 RegisterList LDRD_register_cccc000pu0w0nnnntttt00001101mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -4230,14 +4230,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register LDREXB_cccc00011101nnnntttt111110011111_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDREXB_cccc00011101nnnntttt111110011111_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4245,7 +4245,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LDREXB_cccc00011101nnnntttt111110011111_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4261,7 +4261,7 @@ safety(Instruction inst) const {
 
 RegisterList LDREXB_cccc00011101nnnntttt111110011111_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -4310,14 +4310,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register LDREXD_cccc00011011nnnntttt111110011111_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDREXD_cccc00011011nnnntttt111110011111_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(15:12) + 1}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -4326,7 +4326,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LDREXD_cccc00011011nnnntttt111110011111_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(15:12)(0)=1 ||
   //       14  ==
@@ -4345,7 +4345,7 @@ safety(Instruction inst) const {
 
 RegisterList LDREXD_cccc00011011nnnntttt111110011111_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -4388,14 +4388,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register LDREX_cccc00011001nnnntttt111110011111_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDREX_cccc00011001nnnntttt111110011111_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4403,7 +4403,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LDREX_cccc00011001nnnntttt111110011111_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4419,7 +4419,7 @@ safety(Instruction inst) const {
 
 RegisterList LDREX_cccc00011001nnnntttt111110011111_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -4496,14 +4496,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //         (W(21)=1)}
 Register LDRH_immediate_cccc000pu1w1nnnnttttiiii1011iiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDRH_immediate_cccc000pu1w1nnnnttttiiii1011iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -4520,7 +4520,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LDRH_immediate_cccc000pu1w1nnnnttttiiii1011iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:16)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0x000F0000)  ==
@@ -4561,7 +4561,7 @@ safety(Instruction inst) const {
 bool LDRH_immediate_cccc000pu1w1nnnnttttiiii1011iiii_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(inst(24)=0) ||
   //       (inst(21)=1)'
   return (((inst.Bits() & 0x01000000)  ==
@@ -4572,7 +4572,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList LDRH_immediate_cccc000pu1w1nnnnttttiiii1011iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -4632,14 +4632,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register LDRH_literal_cccc000pu1w11111ttttiiii1011iiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: '15'
   return Register(15);
 }
 
 RegisterList LDRH_literal_cccc000pu1w11111ttttiiii1011iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4647,14 +4647,14 @@ defs(Instruction inst) const {
 
 bool LDRH_literal_cccc000pu1w11111ttttiiii1011iiii_case_0::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: 'true'
   return true;
 }
 
 SafetyLevel LDRH_literal_cccc000pu1w11111ttttiiii1011iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -4680,7 +4680,7 @@ safety(Instruction inst) const {
 
 RegisterList LDRH_literal_cccc000pu1w11111ttttiiii1011iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -4753,14 +4753,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //         (W(21)=1)}
 Register LDRH_register_cccc000pu0w1nnnntttt00001011mmmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDRH_register_cccc000pu0w1nnnntttt00001011mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -4777,7 +4777,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LDRH_register_cccc000pu0w1nnnntttt00001011mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -4834,7 +4834,7 @@ safety(Instruction inst) const {
 
 RegisterList LDRH_register_cccc000pu0w1nnnntttt00001011mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -4912,14 +4912,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //         (W(21)=1)}
 Register LDRSB_immediate_cccc000pu1w1nnnnttttiiii1101iiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDRSB_immediate_cccc000pu1w1nnnnttttiiii1101iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -4936,7 +4936,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LDRSB_immediate_cccc000pu1w1nnnnttttiiii1101iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:16)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0x000F0000)  ==
@@ -4977,7 +4977,7 @@ safety(Instruction inst) const {
 bool LDRSB_immediate_cccc000pu1w1nnnnttttiiii1101iiii_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(inst(24)=0) ||
   //       (inst(21)=1)'
   return (((inst.Bits() & 0x01000000)  ==
@@ -4988,7 +4988,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList LDRSB_immediate_cccc000pu1w1nnnnttttiiii1101iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -5048,14 +5048,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register LDRSB_literal_cccc0001u1011111ttttiiii1101iiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: '15'
   return Register(15);
 }
 
 RegisterList LDRSB_literal_cccc0001u1011111ttttiiii1101iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5063,14 +5063,14 @@ defs(Instruction inst) const {
 
 bool LDRSB_literal_cccc0001u1011111ttttiiii1101iiii_case_0::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: 'true'
   return true;
 }
 
 SafetyLevel LDRSB_literal_cccc0001u1011111ttttiiii1101iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -5096,7 +5096,7 @@ safety(Instruction inst) const {
 
 RegisterList LDRSB_literal_cccc0001u1011111ttttiiii1101iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -5169,14 +5169,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //         (W(21)=1)}
 Register LDRSB_register_cccc000pu0w1nnnntttt00001101mmmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDRSB_register_cccc000pu0w1nnnntttt00001101mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -5193,7 +5193,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LDRSB_register_cccc000pu0w1nnnntttt00001101mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -5250,7 +5250,7 @@ safety(Instruction inst) const {
 
 RegisterList LDRSB_register_cccc000pu0w1nnnntttt00001101mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -5328,14 +5328,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //         (W(21)=1)}
 Register LDRSH_immediate_cccc000pu1w1nnnnttttiiii1111iiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDRSH_immediate_cccc000pu1w1nnnnttttiiii1111iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -5352,7 +5352,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LDRSH_immediate_cccc000pu1w1nnnnttttiiii1111iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:16)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0x000F0000)  ==
@@ -5393,7 +5393,7 @@ safety(Instruction inst) const {
 bool LDRSH_immediate_cccc000pu1w1nnnnttttiiii1111iiii_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(inst(24)=0) ||
   //       (inst(21)=1)'
   return (((inst.Bits() & 0x01000000)  ==
@@ -5404,7 +5404,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList LDRSH_immediate_cccc000pu1w1nnnnttttiiii1111iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -5464,14 +5464,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register LDRSH_literal_cccc0001u1011111ttttiiii1111iiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: '15'
   return Register(15);
 }
 
 RegisterList LDRSH_literal_cccc0001u1011111ttttiiii1111iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5479,14 +5479,14 @@ defs(Instruction inst) const {
 
 bool LDRSH_literal_cccc0001u1011111ttttiiii1111iiii_case_0::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: 'true'
   return true;
 }
 
 SafetyLevel LDRSH_literal_cccc0001u1011111ttttiiii1111iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -5512,7 +5512,7 @@ safety(Instruction inst) const {
 
 RegisterList LDRSH_literal_cccc0001u1011111ttttiiii1111iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -5585,14 +5585,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //         (W(21)=1)}
 Register LDRSH_register_cccc000pu0w1nnnntttt00001111mmmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDRSH_register_cccc000pu0w1nnnntttt00001111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -5609,7 +5609,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LDRSH_register_cccc000pu0w1nnnntttt00001111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -5666,7 +5666,7 @@ safety(Instruction inst) const {
 
 RegisterList LDRSH_register_cccc000pu0w1nnnntttt00001111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -5702,14 +5702,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    uses: {}}
 RegisterList LDRT_A1_cccc0100u011nnnnttttiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel LDRT_A1_cccc0100u011nnnnttttiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -5721,7 +5721,7 @@ safety(Instruction inst) const {
 
 RegisterList LDRT_A1_cccc0100u011nnnnttttiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5736,14 +5736,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList LDRT_A2_cccc0110u011nnnnttttiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel LDRT_A2_cccc0110u011nnnnttttiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -5755,7 +5755,7 @@ safety(Instruction inst) const {
 
 RegisterList LDRT_A2_cccc0110u011nnnnttttiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5810,14 +5810,14 @@ uses(Instruction inst) const {
 //         W(21)=1}
 Register LDR_immediate_cccc010pu0w1nnnnttttiiiiiiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDR_immediate_cccc010pu0w1nnnnttttiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)
   //       if inst(24)=0 ||
   //       inst(21)=1
@@ -5834,7 +5834,7 @@ defs(Instruction inst) const {
 
 bool LDR_immediate_cccc010pu0w1nnnnttttiiiiiiiiiiii_case_0::
 is_load_thread_address_pointer(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_load_tp: '9  ==
   //          inst(19:16) &&
   //       inst(24)=1 &&
@@ -5860,7 +5860,7 @@ is_load_thread_address_pointer(Instruction inst) const {
 
 SafetyLevel LDR_immediate_cccc010pu0w1nnnnttttiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) => DECODER_ERROR
@@ -5898,7 +5898,7 @@ safety(Instruction inst) const {
 bool LDR_immediate_cccc010pu0w1nnnnttttiiiiiiiiiiii_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(24)=0 ||
   //       inst(21)=1'
   return ((inst.Bits() & 0x01000000)  ==
@@ -5909,7 +5909,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList LDR_immediate_cccc010pu0w1nnnnttttiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -5956,14 +5956,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register LDR_literal_cccc0101u0011111ttttiiiiiiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: '15'
   return Register(15);
 }
 
 RegisterList LDR_literal_cccc0101u0011111ttttiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5971,14 +5971,14 @@ defs(Instruction inst) const {
 
 bool LDR_literal_cccc0101u0011111ttttiiiiiiiiiiii_case_0::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: 'true'
   return true;
 }
 
 SafetyLevel LDR_literal_cccc0101u0011111ttttiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) => FORBIDDEN_OPERANDS
@@ -5991,7 +5991,7 @@ safety(Instruction inst) const {
 
 RegisterList LDR_literal_cccc0101u0011111ttttiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -6070,14 +6070,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //         W(21)=1}
 Register LDR_register_cccc011pu0w1nnnnttttiiiiitt0mmmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList LDR_register_cccc011pu0w1nnnnttttiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)
   //       if inst(24)=0 ||
   //       inst(21)=1
@@ -6094,7 +6094,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LDR_register_cccc011pu0w1nnnnttttiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -6153,7 +6153,7 @@ safety(Instruction inst) const {
 
 RegisterList LDR_register_cccc011pu0w1nnnnttttiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(19:16)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -6208,7 +6208,7 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    uses: {Rm}}
 RegisterList LSL_immediate_cccc0001101s0000ddddiiiii000mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -6221,7 +6221,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LSL_immediate_cccc0001101s0000ddddiiiii000mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -6247,7 +6247,7 @@ safety(Instruction inst) const {
 
 RegisterList LSL_immediate_cccc0001101s0000ddddiiiii000mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -6274,7 +6274,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList LSL_register_cccc0001101s0000ddddmmmm0001nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -6288,7 +6288,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LSL_register_cccc0001101s0000ddddmmmm0001nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -6307,7 +6307,7 @@ safety(Instruction inst) const {
 
 RegisterList LSL_register_cccc0001101s0000ddddmmmm0001nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -6342,7 +6342,7 @@ uses(Instruction inst) const {
 //    uses: {Rm}}
 RegisterList LSR_immediate_cccc0001101s0000ddddiiiii010mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -6355,7 +6355,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LSR_immediate_cccc0001101s0000ddddiiiii010mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -6376,7 +6376,7 @@ safety(Instruction inst) const {
 
 RegisterList LSR_immediate_cccc0001101s0000ddddiiiii010mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -6403,7 +6403,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList LSR_register_cccc0001101s0000ddddmmmm0011nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -6417,7 +6417,7 @@ defs(Instruction inst) const {
 
 SafetyLevel LSR_register_cccc0001101s0000ddddmmmm0011nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -6436,7 +6436,7 @@ safety(Instruction inst) const {
 
 RegisterList LSR_register_cccc0001101s0000ddddmmmm0011nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -6454,14 +6454,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList MCR2_11111110iii0iiiittttiiiiiii1iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel MCR2_11111110iii0iiiittttiiiiiii1iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -6473,7 +6473,7 @@ safety(Instruction inst) const {
 
 RegisterList MCR2_11111110iii0iiiittttiiiiiii1iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6489,14 +6489,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList MCRR2_111111000100ssssttttiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel MCRR2_111111000100ssssttttiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -6508,7 +6508,7 @@ safety(Instruction inst) const {
 
 RegisterList MCRR2_111111000100ssssttttiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6524,14 +6524,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList MCRR_cccc11000100ttttttttccccoooommmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel MCRR_cccc11000100ttttttttccccoooommmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -6543,7 +6543,7 @@ safety(Instruction inst) const {
 
 RegisterList MCRR_cccc11000100ttttttttccccoooommmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6563,7 +6563,7 @@ uses(Instruction inst) const {
 //     error('Consider using DSB (defined in ARMv7) for memory barrier')]}
 RegisterList MCR_cccc1110ooo0nnnnttttccccooo1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
@@ -6592,7 +6592,7 @@ generate_diagnostics(ViolationSet violations,
 
 SafetyLevel MCR_cccc1110ooo0nnnnttttccccooo1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -6604,7 +6604,7 @@ safety(Instruction inst) const {
 
 RegisterList MCR_cccc1110ooo0nnnnttttccccooo1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6661,7 +6661,7 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    uses: {Rn, Rm, Ra}}
 RegisterList MLA_A1_cccc0000001sddddaaaammmm1001nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16), 16
   //       if inst(20)=1
   //       else 32}'
@@ -6675,7 +6675,7 @@ defs(Instruction inst) const {
 
 SafetyLevel MLA_A1_cccc0000001sddddaaaammmm1001nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -6705,7 +6705,7 @@ safety(Instruction inst) const {
 
 RegisterList MLA_A1_cccc0000001sddddaaaammmm1001nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8), inst(15:12)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -6730,7 +6730,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Ra}}
 RegisterList MLS_A1_cccc00000110ddddaaaammmm1001nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -6738,7 +6738,7 @@ defs(Instruction inst) const {
 
 SafetyLevel MLS_A1_cccc00000110ddddaaaammmm1001nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -6760,7 +6760,7 @@ safety(Instruction inst) const {
 
 RegisterList MLS_A1_cccc00000110ddddaaaammmm1001nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8), inst(15:12)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -6813,7 +6813,7 @@ uses(Instruction inst) const {
 //    unsigned: U(23)=1}
 RegisterList MOVE_scalar_to_ARM_core_register_cccc1110iii1nnnntttt1011nii10000_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -6821,7 +6821,7 @@ defs(Instruction inst) const {
 
 SafetyLevel MOVE_scalar_to_ARM_core_register_cccc1110iii1nnnntttt1011nii10000_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(23):inst(22:21):inst(6:5)(4:0)=10x00 ||
   //       inst(23):inst(22:21):inst(6:5)(4:0)=x0x10 => UNDEFINED
@@ -6862,7 +6862,7 @@ safety(Instruction inst) const {
 //    uses: {}}
 RegisterList MOVT_cccc00110100iiiiddddiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -6887,7 +6887,7 @@ dynamic_code_replacement_sentinel(
 
 SafetyLevel MOVT_cccc00110100iiiiddddiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(15:12)=1111 => UNPREDICTABLE
   if ((inst.Bits() & 0x0000F000)  ==
@@ -6900,7 +6900,7 @@ safety(Instruction inst) const {
 
 RegisterList MOVT_cccc00110100iiiiddddiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6927,7 +6927,7 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList MOVW_cccc00110000iiiiddddiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -6952,7 +6952,7 @@ dynamic_code_replacement_sentinel(
 
 SafetyLevel MOVW_cccc00110000iiiiddddiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(15:12)=1111 => UNPREDICTABLE
   if ((inst.Bits() & 0x0000F000)  ==
@@ -6965,7 +6965,7 @@ safety(Instruction inst) const {
 
 RegisterList MOVW_cccc00110000iiiiddddiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6993,7 +6993,7 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList MOV_immediate_A1_cccc0011101s0000ddddiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -7017,7 +7017,7 @@ dynamic_code_replacement_sentinel(
 
 SafetyLevel MOV_immediate_A1_cccc0011101s0000ddddiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -7038,7 +7038,7 @@ safety(Instruction inst) const {
 
 RegisterList MOV_immediate_A1_cccc0011101s0000ddddiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7063,7 +7063,7 @@ uses(Instruction inst) const {
 //    uses: {Rm}}
 RegisterList MOV_register_cccc0001101s0000dddd00000000mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -7076,7 +7076,7 @@ defs(Instruction inst) const {
 
 SafetyLevel MOV_register_cccc0001101s0000dddd00000000mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -7097,7 +7097,7 @@ safety(Instruction inst) const {
 
 RegisterList MOV_register_cccc0001101s0000dddd00000000mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -7114,14 +7114,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList MRC2_11111110iii1iiiittttiiiiiii1iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel MRC2_11111110iii1iiiittttiiiiiii1iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -7133,7 +7133,7 @@ safety(Instruction inst) const {
 
 RegisterList MRC2_11111110iii1iiiittttiiiiiii1iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7148,14 +7148,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList MRC_cccc1110ooo1nnnnttttccccooo1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel MRC_cccc1110ooo1nnnnttttccccooo1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -7167,7 +7167,7 @@ safety(Instruction inst) const {
 
 RegisterList MRC_cccc1110ooo1nnnnttttccccooo1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7183,14 +7183,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList MRRC2_111111000101ssssttttiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel MRRC2_111111000101ssssttttiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -7202,7 +7202,7 @@ safety(Instruction inst) const {
 
 RegisterList MRRC2_111111000101ssssttttiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7218,14 +7218,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList MRRC_cccc11000101ttttttttccccoooommmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel MRRC_cccc11000101ttttttttccccoooommmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -7237,7 +7237,7 @@ safety(Instruction inst) const {
 
 RegisterList MRRC_cccc11000101ttttttttccccoooommmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7253,14 +7253,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList MRS_Banked_register_cccc00010r00mmmmdddd001m00000000_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel MRS_Banked_register_cccc00010r00mmmmdddd001m00000000_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -7272,7 +7272,7 @@ safety(Instruction inst) const {
 
 RegisterList MRS_Banked_register_cccc00010r00mmmmdddd001m00000000_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7288,14 +7288,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList MRS_Banked_register_cccc00010r10mmmm1111001m0000nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel MRS_Banked_register_cccc00010r10mmmm1111001m0000nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -7307,7 +7307,7 @@ safety(Instruction inst) const {
 
 RegisterList MRS_Banked_register_cccc00010r10mmmm1111001m0000nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7327,7 +7327,7 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList MRS_cccc00010r001111dddd000000000000_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -7335,7 +7335,7 @@ defs(Instruction inst) const {
 
 SafetyLevel MRS_cccc00010r001111dddd000000000000_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(22)=1 => FORBIDDEN_OPERANDS
   if ((inst.Bits() & 0x00400000)  ==
@@ -7353,7 +7353,7 @@ safety(Instruction inst) const {
 
 RegisterList MRS_cccc00010r001111dddd000000000000_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7378,7 +7378,7 @@ uses(Instruction inst) const {
 //    write_nzcvq: mask(1)=1}
 RegisterList MSR_immediate_cccc00110010mm001111iiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16
   //       if inst(19:18)(1)=1
   //       else 32}'
@@ -7391,7 +7391,7 @@ defs(Instruction inst) const {
 
 SafetyLevel MSR_immediate_cccc00110010mm001111iiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=00 => DECODER_ERROR
   if ((inst.Bits() & 0x000C0000)  ==
@@ -7404,7 +7404,7 @@ safety(Instruction inst) const {
 
 RegisterList MSR_immediate_cccc00110010mm001111iiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7419,14 +7419,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList MSR_immediate_cccc00110r10mmmm1111iiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel MSR_immediate_cccc00110r10mmmm1111iiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -7438,7 +7438,7 @@ safety(Instruction inst) const {
 
 RegisterList MSR_immediate_cccc00110r10mmmm1111iiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7465,7 +7465,7 @@ uses(Instruction inst) const {
 //    write_nzcvq: mask(1)=1}
 RegisterList MSR_register_cccc00010010mm00111100000000nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16
   //       if inst(19:18)(1)=1
   //       else 32}'
@@ -7478,7 +7478,7 @@ defs(Instruction inst) const {
 
 SafetyLevel MSR_register_cccc00010010mm00111100000000nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=00 => UNPREDICTABLE
   if ((inst.Bits() & 0x000C0000)  ==
@@ -7496,7 +7496,7 @@ safety(Instruction inst) const {
 
 RegisterList MSR_register_cccc00010010mm00111100000000nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -7512,14 +7512,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList MSR_register_cccc00010r10mmmm111100000000nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel MSR_register_cccc00010r10mmmm111100000000nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -7531,7 +7531,7 @@ safety(Instruction inst) const {
 
 RegisterList MSR_register_cccc00010r10mmmm111100000000nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7561,7 +7561,7 @@ uses(Instruction inst) const {
 //    uses: {Rm, Rn}}
 RegisterList MUL_A1_cccc0000000sdddd0000mmmm1001nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16), 16
   //       if inst(20)=1
   //       else 32}'
@@ -7575,7 +7575,7 @@ defs(Instruction inst) const {
 
 SafetyLevel MUL_A1_cccc0000000sdddd0000mmmm1001nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -7602,7 +7602,7 @@ safety(Instruction inst) const {
 
 RegisterList MUL_A1_cccc0000000sdddd0000mmmm1001nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(11:8), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x00000F00) >> 8))).
@@ -7632,7 +7632,7 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList MVN_immediate_cccc0011111s0000ddddiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -7656,7 +7656,7 @@ dynamic_code_replacement_sentinel(
 
 SafetyLevel MVN_immediate_cccc0011111s0000ddddiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -7677,7 +7677,7 @@ safety(Instruction inst) const {
 
 RegisterList MVN_immediate_cccc0011111s0000ddddiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7710,7 +7710,7 @@ uses(Instruction inst) const {
 //    uses: {Rm}}
 RegisterList MVN_register_cccc0001111s0000ddddiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -7723,7 +7723,7 @@ defs(Instruction inst) const {
 
 SafetyLevel MVN_register_cccc0001111s0000ddddiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -7744,7 +7744,7 @@ safety(Instruction inst) const {
 
 RegisterList MVN_register_cccc0001111s0000ddddiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -7778,7 +7778,7 @@ uses(Instruction inst) const {
 //    uses: {Rm, Rs}}
 RegisterList MVN_register_shifted_register_cccc0001111s0000ddddssss0tt1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -7792,7 +7792,7 @@ defs(Instruction inst) const {
 
 SafetyLevel MVN_register_shifted_register_cccc0001111s0000ddddssss0tt1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -7811,7 +7811,7 @@ safety(Instruction inst) const {
 
 RegisterList MVN_register_shifted_register_cccc0001111s0000ddddssss0tt1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -7827,14 +7827,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList NOP_cccc0011001000001111000000000000_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel NOP_cccc0011001000001111000000000000_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -7842,7 +7842,7 @@ safety(Instruction inst) const {
 
 RegisterList NOP_cccc0011001000001111000000000000_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7856,14 +7856,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList NOT_IMPLEMENTED_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel NOT_IMPLEMENTED_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => NOT_IMPLEMENTED
   if (true)
@@ -7875,7 +7875,7 @@ safety(Instruction inst) const {
 
 RegisterList NOT_IMPLEMENTED_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7904,7 +7904,7 @@ uses(Instruction inst) const {
 //    uses: {Rn}}
 RegisterList ORR_immediate_cccc0011100snnnnddddiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -7928,7 +7928,7 @@ dynamic_code_replacement_sentinel(
 
 SafetyLevel ORR_immediate_cccc0011100snnnnddddiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -7949,7 +7949,7 @@ safety(Instruction inst) const {
 
 RegisterList ORR_immediate_cccc0011100snnnnddddiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -7985,7 +7985,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList ORR_register_cccc0001100snnnnddddiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -7998,7 +7998,7 @@ defs(Instruction inst) const {
 
 SafetyLevel ORR_register_cccc0001100snnnnddddiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -8019,7 +8019,7 @@ safety(Instruction inst) const {
 
 RegisterList ORR_register_cccc0001100snnnnddddiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -8056,7 +8056,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Rs}}
 RegisterList ORR_register_shifted_register_cccc0001100snnnnddddssss0tt1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -8070,7 +8070,7 @@ defs(Instruction inst) const {
 
 SafetyLevel ORR_register_shifted_register_cccc0001100snnnnddddssss0tt1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -8092,7 +8092,7 @@ safety(Instruction inst) const {
 
 RegisterList ORR_register_shifted_register_cccc0001100snnnnddddssss0tt1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -8125,7 +8125,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList PKH_cccc01101000nnnnddddiiiiit01mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -8133,7 +8133,7 @@ defs(Instruction inst) const {
 
 SafetyLevel PKH_cccc01101000nnnnddddiiiiit01mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -8152,7 +8152,7 @@ safety(Instruction inst) const {
 
 RegisterList PKH_cccc01101000nnnnddddiiiiit01mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -8183,21 +8183,21 @@ uses(Instruction inst) const {
 //    violations: [implied by 'base']}
 Register PLD_PLDW_immediate_11110101ur01nnnn1111iiiiiiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList PLD_PLDW_immediate_11110101ur01nnnn1111iiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 bool PLD_PLDW_immediate_11110101ur01nnnn1111iiiiiiiiiiii_case_0::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: '15  ==
   //          inst(19:16)'
   return ((((inst.Bits() & 0x000F0000) >> 16)) == (15));
@@ -8205,7 +8205,7 @@ is_literal_load(Instruction inst) const {
 
 SafetyLevel PLD_PLDW_immediate_11110101ur01nnnn1111iiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:16)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0x000F0000)  ==
@@ -8218,7 +8218,7 @@ safety(Instruction inst) const {
 
 RegisterList PLD_PLDW_immediate_11110101ur01nnnn1111iiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -8267,21 +8267,21 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register PLD_PLDW_immediate_11110101ur01nnnn1111iiiiiiiiiiii_case_1::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList PLD_PLDW_immediate_11110101ur01nnnn1111iiiiiiiiiiii_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 bool PLD_PLDW_immediate_11110101ur01nnnn1111iiiiiiiiiiii_case_1::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: '15  ==
   //          inst(19:16)'
   return ((((inst.Bits() & 0x000F0000) >> 16)) == (15));
@@ -8289,7 +8289,7 @@ is_literal_load(Instruction inst) const {
 
 SafetyLevel PLD_PLDW_immediate_11110101ur01nnnn1111iiiiiiiiiiii_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:16)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0x000F0000)  ==
@@ -8302,7 +8302,7 @@ safety(Instruction inst) const {
 
 RegisterList PLD_PLDW_immediate_11110101ur01nnnn1111iiiiiiiiiiii_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -8356,21 +8356,21 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register PLD_PLDW_register_11110111u001nnnn1111iiiiitt0mmmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList PLD_PLDW_register_11110111u001nnnn1111iiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel PLD_PLDW_register_11110111u001nnnn1111iiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(3:0) ||
@@ -8393,7 +8393,7 @@ safety(Instruction inst) const {
 
 RegisterList PLD_PLDW_register_11110111u001nnnn1111iiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(19:16)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -8448,21 +8448,21 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register PLD_PLDW_register_11110111u101nnnn1111iiiiitt0mmmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList PLD_PLDW_register_11110111u101nnnn1111iiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel PLD_PLDW_register_11110111u101nnnn1111iiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(3:0) ||
@@ -8485,7 +8485,7 @@ safety(Instruction inst) const {
 
 RegisterList PLD_PLDW_register_11110111u101nnnn1111iiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(19:16)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -8531,28 +8531,28 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register PLD_literal_11110101u10111111111iiiiiiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: '15'
   return Register(15);
 }
 
 RegisterList PLD_literal_11110101u10111111111iiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 bool PLD_literal_11110101u10111111111iiiiiiiiiiii_case_0::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: 'true'
   return true;
 }
 
 SafetyLevel PLD_literal_11110101u10111111111iiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => MAY_BE_SAFE
   if (true)
@@ -8564,7 +8564,7 @@ safety(Instruction inst) const {
 
 RegisterList PLD_literal_11110101u10111111111iiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{15}'
   return RegisterList().
    Add(Register(15));
@@ -8611,21 +8611,21 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register PLI_immediate_literal_11110100u101nnnn1111iiiiiiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList PLI_immediate_literal_11110100u101nnnn1111iiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 bool PLI_immediate_literal_11110100u101nnnn1111iiiiiiiiiiii_case_0::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: '15  ==
   //          inst(19:16)'
   return ((((inst.Bits() & 0x000F0000) >> 16)) == (15));
@@ -8633,7 +8633,7 @@ is_literal_load(Instruction inst) const {
 
 SafetyLevel PLI_immediate_literal_11110100u101nnnn1111iiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => MAY_BE_SAFE
   if (true)
@@ -8645,7 +8645,7 @@ safety(Instruction inst) const {
 
 RegisterList PLI_immediate_literal_11110100u101nnnn1111iiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -8694,21 +8694,21 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register PLI_register_11110110u101nnnn1111iiiiitt0mmmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList PLI_register_11110110u101nnnn1111iiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel PLI_register_11110110u101nnnn1111iiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(3:0) => UNPREDICTABLE
@@ -8725,7 +8725,7 @@ safety(Instruction inst) const {
 
 RegisterList PLI_register_11110110u101nnnn1111iiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(19:16)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -8767,7 +8767,7 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    uses: {Rn, Rm}}
 RegisterList QADD16_cccc01100010nnnndddd11110001mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -8775,7 +8775,7 @@ defs(Instruction inst) const {
 
 SafetyLevel QADD16_cccc01100010nnnndddd11110001mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -8794,7 +8794,7 @@ safety(Instruction inst) const {
 
 RegisterList QADD16_cccc01100010nnnndddd11110001mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -8817,7 +8817,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList QADD8_cccc01100010nnnndddd11111001mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -8825,7 +8825,7 @@ defs(Instruction inst) const {
 
 SafetyLevel QADD8_cccc01100010nnnndddd11111001mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -8844,7 +8844,7 @@ safety(Instruction inst) const {
 
 RegisterList QADD8_cccc01100010nnnndddd11111001mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -8867,7 +8867,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList QADD_cccc00010000nnnndddd00000101mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -8875,7 +8875,7 @@ defs(Instruction inst) const {
 
 SafetyLevel QADD_cccc00010000nnnndddd00000101mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -8894,7 +8894,7 @@ safety(Instruction inst) const {
 
 RegisterList QADD_cccc00010000nnnndddd00000101mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -8917,7 +8917,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList QASX_cccc01100010nnnndddd11110011mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -8925,7 +8925,7 @@ defs(Instruction inst) const {
 
 SafetyLevel QASX_cccc01100010nnnndddd11110011mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -8944,7 +8944,7 @@ safety(Instruction inst) const {
 
 RegisterList QASX_cccc01100010nnnndddd11110011mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -8967,7 +8967,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList QDADD_cccc00010100nnnndddd00000101mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -8975,7 +8975,7 @@ defs(Instruction inst) const {
 
 SafetyLevel QDADD_cccc00010100nnnndddd00000101mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -8994,7 +8994,7 @@ safety(Instruction inst) const {
 
 RegisterList QDADD_cccc00010100nnnndddd00000101mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -9017,7 +9017,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList QDSUB_cccc00010110nnnndddd00000101mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -9025,7 +9025,7 @@ defs(Instruction inst) const {
 
 SafetyLevel QDSUB_cccc00010110nnnndddd00000101mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -9044,7 +9044,7 @@ safety(Instruction inst) const {
 
 RegisterList QDSUB_cccc00010110nnnndddd00000101mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -9067,7 +9067,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList QSAX_cccc01100010nnnndddd11110101mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -9075,7 +9075,7 @@ defs(Instruction inst) const {
 
 SafetyLevel QSAX_cccc01100010nnnndddd11110101mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -9094,7 +9094,7 @@ safety(Instruction inst) const {
 
 RegisterList QSAX_cccc01100010nnnndddd11110101mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -9117,7 +9117,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList QSUB16_cccc01100010nnnndddd11110111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -9125,7 +9125,7 @@ defs(Instruction inst) const {
 
 SafetyLevel QSUB16_cccc01100010nnnndddd11110111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -9144,7 +9144,7 @@ safety(Instruction inst) const {
 
 RegisterList QSUB16_cccc01100010nnnndddd11110111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -9167,7 +9167,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList QSUB8_cccc01100010nnnndddd11111111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -9175,7 +9175,7 @@ defs(Instruction inst) const {
 
 SafetyLevel QSUB8_cccc01100010nnnndddd11111111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -9194,7 +9194,7 @@ safety(Instruction inst) const {
 
 RegisterList QSUB8_cccc01100010nnnndddd11111111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -9217,7 +9217,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList QSUB_cccc00010010nnnndddd00000101mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -9225,7 +9225,7 @@ defs(Instruction inst) const {
 
 SafetyLevel QSUB_cccc00010010nnnndddd00000101mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -9244,7 +9244,7 @@ safety(Instruction inst) const {
 
 RegisterList QSUB_cccc00010010nnnndddd00000101mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -9266,7 +9266,7 @@ uses(Instruction inst) const {
 //    uses: {Rm}}
 RegisterList RBIT_cccc011011111111dddd11110011mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -9274,7 +9274,7 @@ defs(Instruction inst) const {
 
 SafetyLevel RBIT_cccc011011111111dddd11110011mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -9290,7 +9290,7 @@ safety(Instruction inst) const {
 
 RegisterList RBIT_cccc011011111111dddd11110011mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -9311,7 +9311,7 @@ uses(Instruction inst) const {
 //    uses: {Rm}}
 RegisterList REV16_cccc011010111111dddd11111011mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -9319,7 +9319,7 @@ defs(Instruction inst) const {
 
 SafetyLevel REV16_cccc011010111111dddd11111011mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -9335,7 +9335,7 @@ safety(Instruction inst) const {
 
 RegisterList REV16_cccc011010111111dddd11111011mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -9356,7 +9356,7 @@ uses(Instruction inst) const {
 //    uses: {Rm}}
 RegisterList REVSH_cccc011011111111dddd11111011mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -9364,7 +9364,7 @@ defs(Instruction inst) const {
 
 SafetyLevel REVSH_cccc011011111111dddd11111011mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -9380,7 +9380,7 @@ safety(Instruction inst) const {
 
 RegisterList REVSH_cccc011011111111dddd11111011mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -9401,7 +9401,7 @@ uses(Instruction inst) const {
 //    uses: {Rm}}
 RegisterList REV_cccc011010111111dddd11110011mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -9409,7 +9409,7 @@ defs(Instruction inst) const {
 
 SafetyLevel REV_cccc011010111111dddd11110011mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -9425,7 +9425,7 @@ safety(Instruction inst) const {
 
 RegisterList REV_cccc011010111111dddd11110011mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -9442,14 +9442,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList RFE_1111100pu0w1nnnn0000101000000000_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel RFE_1111100pu0w1nnnn0000101000000000_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -9461,7 +9461,7 @@ safety(Instruction inst) const {
 
 RegisterList RFE_1111100pu0w1nnnn0000101000000000_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9495,7 +9495,7 @@ uses(Instruction inst) const {
 //    uses: {Rm}}
 RegisterList ROR_immediate_cccc0001101s0000ddddiiiii110mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -9508,7 +9508,7 @@ defs(Instruction inst) const {
 
 SafetyLevel ROR_immediate_cccc0001101s0000ddddiiiii110mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -9534,7 +9534,7 @@ safety(Instruction inst) const {
 
 RegisterList ROR_immediate_cccc0001101s0000ddddiiiii110mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -9561,7 +9561,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList ROR_register_cccc0001101s0000ddddmmmm0111nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -9575,7 +9575,7 @@ defs(Instruction inst) const {
 
 SafetyLevel ROR_register_cccc0001101s0000ddddmmmm0111nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -9594,7 +9594,7 @@ safety(Instruction inst) const {
 
 RegisterList ROR_register_cccc0001101s0000ddddmmmm0111nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -9621,7 +9621,7 @@ uses(Instruction inst) const {
 //    uses: {Rm}}
 RegisterList RRX_cccc0001101s0000dddd00000110mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -9634,7 +9634,7 @@ defs(Instruction inst) const {
 
 SafetyLevel RRX_cccc0001101s0000dddd00000110mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -9655,7 +9655,7 @@ safety(Instruction inst) const {
 
 RegisterList RRX_cccc0001101s0000dddd00000110mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -9684,7 +9684,7 @@ uses(Instruction inst) const {
 //    uses: {Rn}}
 RegisterList RSB_immediate_cccc0010011snnnnddddiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -9698,7 +9698,7 @@ defs(Instruction inst) const {
 
 SafetyLevel RSB_immediate_cccc0010011snnnnddddiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -9719,7 +9719,7 @@ safety(Instruction inst) const {
 
 RegisterList RSB_immediate_cccc0010011snnnnddddiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -9755,7 +9755,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList RSB_register_cccc0000011snnnnddddiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -9768,7 +9768,7 @@ defs(Instruction inst) const {
 
 SafetyLevel RSB_register_cccc0000011snnnnddddiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -9789,7 +9789,7 @@ safety(Instruction inst) const {
 
 RegisterList RSB_register_cccc0000011snnnnddddiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -9826,7 +9826,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Rs}}
 RegisterList RSB_register_shfited_register_cccc0000011snnnnddddssss0tt1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -9840,7 +9840,7 @@ defs(Instruction inst) const {
 
 SafetyLevel RSB_register_shfited_register_cccc0000011snnnnddddssss0tt1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -9862,7 +9862,7 @@ safety(Instruction inst) const {
 
 RegisterList RSB_register_shfited_register_cccc0000011snnnnddddssss0tt1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -9893,7 +9893,7 @@ uses(Instruction inst) const {
 //    uses: {Rn}}
 RegisterList RSC_immediate_cccc0010111snnnnddddiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -9907,7 +9907,7 @@ defs(Instruction inst) const {
 
 SafetyLevel RSC_immediate_cccc0010111snnnnddddiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -9928,7 +9928,7 @@ safety(Instruction inst) const {
 
 RegisterList RSC_immediate_cccc0010111snnnnddddiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -9964,7 +9964,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList RSC_register_cccc0000111snnnnddddiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -9977,7 +9977,7 @@ defs(Instruction inst) const {
 
 SafetyLevel RSC_register_cccc0000111snnnnddddiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -9998,7 +9998,7 @@ safety(Instruction inst) const {
 
 RegisterList RSC_register_cccc0000111snnnnddddiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -10035,7 +10035,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Rs}}
 RegisterList RSC_register_shifted_register_cccc0000111snnnnddddssss0tt1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -10049,7 +10049,7 @@ defs(Instruction inst) const {
 
 SafetyLevel RSC_register_shifted_register_cccc0000111snnnnddddssss0tt1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -10071,7 +10071,7 @@ safety(Instruction inst) const {
 
 RegisterList RSC_register_shifted_register_cccc0000111snnnnddddssss0tt1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -10095,7 +10095,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SADD16_cccc01100001nnnndddd11110001mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -10103,7 +10103,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SADD16_cccc01100001nnnndddd11110001mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -10122,7 +10122,7 @@ safety(Instruction inst) const {
 
 RegisterList SADD16_cccc01100001nnnndddd11110001mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -10145,7 +10145,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SADD8_cccc01100001nnnndddd11111001mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -10153,7 +10153,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SADD8_cccc01100001nnnndddd11111001mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -10172,7 +10172,7 @@ safety(Instruction inst) const {
 
 RegisterList SADD8_cccc01100001nnnndddd11111001mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -10195,7 +10195,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SASX_cccc01100001nnnndddd11110011mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -10203,7 +10203,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SASX_cccc01100001nnnndddd11110011mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -10222,7 +10222,7 @@ safety(Instruction inst) const {
 
 RegisterList SASX_cccc01100001nnnndddd11110011mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -10252,7 +10252,7 @@ uses(Instruction inst) const {
 //    uses: {Rn}}
 RegisterList SBC_immediate_cccc0010110snnnnddddiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -10266,7 +10266,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SBC_immediate_cccc0010110snnnnddddiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -10287,7 +10287,7 @@ safety(Instruction inst) const {
 
 RegisterList SBC_immediate_cccc0010110snnnnddddiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -10323,7 +10323,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SBC_register_cccc0000110snnnnddddiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -10336,7 +10336,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SBC_register_cccc0000110snnnnddddiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -10357,7 +10357,7 @@ safety(Instruction inst) const {
 
 RegisterList SBC_register_cccc0000110snnnnddddiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -10394,7 +10394,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Rs}}
 RegisterList SBC_register_shifted_register_cccc0000110snnnnddddssss0tt1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -10408,7 +10408,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SBC_register_shifted_register_cccc0000110snnnnddddssss0tt1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -10430,7 +10430,7 @@ safety(Instruction inst) const {
 
 RegisterList SBC_register_shifted_register_cccc0000110snnnnddddssss0tt1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -10457,7 +10457,7 @@ uses(Instruction inst) const {
 //    widthm1: widthm1(20:16)}
 RegisterList SBFX_cccc0111101wwwwwddddlllll101nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -10465,7 +10465,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SBFX_cccc0111101wwwwwddddlllll101nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -10486,7 +10486,7 @@ safety(Instruction inst) const {
 
 RegisterList SBFX_cccc0111101wwwwwddddlllll101nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -10509,7 +10509,7 @@ uses(Instruction inst) const {
 //    uses: {Rm, Rn}}
 RegisterList SDIV_cccc01110001dddd1111mmmm0001nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -10517,7 +10517,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SDIV_cccc01110001dddd1111mmmm0001nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -10536,7 +10536,7 @@ safety(Instruction inst) const {
 
 RegisterList SDIV_cccc01110001dddd1111mmmm0001nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(11:8), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x00000F00) >> 8))).
@@ -10559,7 +10559,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SEL_cccc01101000nnnndddd11111011mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -10567,7 +10567,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SEL_cccc01101000nnnndddd11111011mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -10586,7 +10586,7 @@ safety(Instruction inst) const {
 
 RegisterList SEL_cccc01101000nnnndddd11111011mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -10604,14 +10604,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList SETEND_1111000100000001000000i000000000_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel SETEND_1111000100000001000000i000000000_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -10623,7 +10623,7 @@ safety(Instruction inst) const {
 
 RegisterList SETEND_1111000100000001000000i000000000_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10639,14 +10639,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList SEV_cccc0011001000001111000000000100_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel SEV_cccc0011001000001111000000000100_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -10658,7 +10658,7 @@ safety(Instruction inst) const {
 
 RegisterList SEV_cccc0011001000001111000000000100_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10679,7 +10679,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SHADD16_cccc01100011nnnndddd11110001mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -10687,7 +10687,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SHADD16_cccc01100011nnnndddd11110001mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -10706,7 +10706,7 @@ safety(Instruction inst) const {
 
 RegisterList SHADD16_cccc01100011nnnndddd11110001mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -10729,7 +10729,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SHADD8_cccc01100011nnnndddd11111001mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -10737,7 +10737,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SHADD8_cccc01100011nnnndddd11111001mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -10756,7 +10756,7 @@ safety(Instruction inst) const {
 
 RegisterList SHADD8_cccc01100011nnnndddd11111001mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -10779,7 +10779,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SHASX_cccc01100011nnnndddd11110011mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -10787,7 +10787,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SHASX_cccc01100011nnnndddd11110011mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -10806,7 +10806,7 @@ safety(Instruction inst) const {
 
 RegisterList SHASX_cccc01100011nnnndddd11110011mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -10829,7 +10829,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SHSAX_cccc01100011nnnndddd11110101mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -10837,7 +10837,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SHSAX_cccc01100011nnnndddd11110101mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -10856,7 +10856,7 @@ safety(Instruction inst) const {
 
 RegisterList SHSAX_cccc01100011nnnndddd11110101mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -10879,7 +10879,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SHSUB16_cccc01100011nnnndddd11110111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -10887,7 +10887,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SHSUB16_cccc01100011nnnndddd11110111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -10906,7 +10906,7 @@ safety(Instruction inst) const {
 
 RegisterList SHSUB16_cccc01100011nnnndddd11110111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -10929,7 +10929,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SHSUB8_cccc01100011nnnndddd11111111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -10937,7 +10937,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SHSUB8_cccc01100011nnnndddd11111111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -10956,7 +10956,7 @@ safety(Instruction inst) const {
 
 RegisterList SHSUB8_cccc01100011nnnndddd11111111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -10974,14 +10974,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList SMC_cccc000101100000000000000111iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel SMC_cccc000101100000000000000111iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -10993,7 +10993,7 @@ safety(Instruction inst) const {
 
 RegisterList SMC_cccc000101100000000000000111iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -11025,7 +11025,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Ra}}
 RegisterList SMLABB_SMLABT_SMLATB_SMLATT_cccc00010000ddddaaaammmm1xx0nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -11033,7 +11033,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SMLABB_SMLABT_SMLATB_SMLATT_cccc00010000ddddaaaammmm1xx0nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -11055,7 +11055,7 @@ safety(Instruction inst) const {
 
 RegisterList SMLABB_SMLABT_SMLATB_SMLATT_cccc00010000ddddaaaammmm1xx0nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8), inst(15:12)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -11083,7 +11083,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Ra}}
 RegisterList SMLAD_cccc01110000ddddaaaammmm00m1nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -11091,7 +11091,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SMLAD_cccc01110000ddddaaaammmm00m1nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) => DECODER_ERROR
@@ -11115,7 +11115,7 @@ safety(Instruction inst) const {
 
 RegisterList SMLAD_cccc01110000ddddaaaammmm00m1nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8), inst(15:12)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -11153,7 +11153,7 @@ uses(Instruction inst) const {
 //    uses: {RdLo, RdHi, Rn, Rm}}
 RegisterList SMLALBB_SMLALBT_SMLALTB_SMLALTT_cccc00010100hhhhllllmmmm1xx0nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -11162,7 +11162,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SMLALBB_SMLALBT_SMLALTB_SMLALTT_cccc00010100hhhhllllmmmm1xx0nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -11189,7 +11189,7 @@ safety(Instruction inst) const {
 
 RegisterList SMLALBB_SMLALBT_SMLALTB_SMLALTT_cccc00010100hhhhllllmmmm1xx0nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12), inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -11223,7 +11223,7 @@ uses(Instruction inst) const {
 //    uses: {RdHi, RdLo, Rm, Rn}}
 RegisterList SMLALD_cccc01110100hhhhllllmmmm00m1nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16), inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -11232,7 +11232,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SMLALD_cccc01110100hhhhllllmmmm00m1nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -11259,7 +11259,7 @@ safety(Instruction inst) const {
 
 RegisterList SMLALD_cccc01110100hhhhllllmmmm00m1nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(15:12), inst(11:8), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -11303,7 +11303,7 @@ uses(Instruction inst) const {
 //    uses: {RdLo, RdHi, Rn, Rm}}
 RegisterList SMLAL_A1_cccc0000111shhhhllllmmmm1001nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16), 16
   //       if inst(20)=1
   //       else 32}'
@@ -11318,7 +11318,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SMLAL_A1_cccc0000111shhhhllllmmmm1001nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -11356,7 +11356,7 @@ safety(Instruction inst) const {
 
 RegisterList SMLAL_A1_cccc0000111shhhhllllmmmm1001nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12), inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -11392,7 +11392,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Ra}}
 RegisterList SMLAWB_SMLAWT_cccc00010010ddddaaaammmm1x00nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -11400,7 +11400,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SMLAWB_SMLAWT_cccc00010010ddddaaaammmm1x00nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -11422,7 +11422,7 @@ safety(Instruction inst) const {
 
 RegisterList SMLAWB_SMLAWT_cccc00010010ddddaaaammmm1x00nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8), inst(15:12)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -11450,7 +11450,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Ra}}
 RegisterList SMLSD_cccc01110000ddddaaaammmm01m1nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -11458,7 +11458,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SMLSD_cccc01110000ddddaaaammmm01m1nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) => DECODER_ERROR
@@ -11482,7 +11482,7 @@ safety(Instruction inst) const {
 
 RegisterList SMLSD_cccc01110000ddddaaaammmm01m1nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8), inst(15:12)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -11515,7 +11515,7 @@ uses(Instruction inst) const {
 //    uses: {RdHi, RdLo, Rm, Rn}}
 RegisterList SMLSLD_cccc01110100hhhhllllmmmm01m1nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16), inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -11524,7 +11524,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SMLSLD_cccc01110100hhhhllllmmmm01m1nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -11551,7 +11551,7 @@ safety(Instruction inst) const {
 
 RegisterList SMLSLD_cccc01110100hhhhllllmmmm01m1nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(15:12), inst(11:8), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).

--- a/src/trusted/validator_arm/gen/arm32_decode_baselines_2.cc
+++ b/src/trusted/validator_arm/gen/arm32_decode_baselines_2.cc
@@ -31,7 +31,7 @@ namespace nacl_arm_dec {
 //    uses: {Rn, Rm, Ra}}
 RegisterList SMMLA_cccc01110101ddddaaaammmm00r1nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -39,7 +39,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SMMLA_cccc01110101ddddaaaammmm00r1nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) => DECODER_ERROR
@@ -63,7 +63,7 @@ safety(Instruction inst) const {
 
 RegisterList SMMLA_cccc01110101ddddaaaammmm00r1nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8), inst(15:12)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -91,7 +91,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Ra}}
 RegisterList SMMLS_cccc01110101ddddaaaammmm11r1nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -99,7 +99,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SMMLS_cccc01110101ddddaaaammmm11r1nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) => DECODER_ERROR
@@ -123,7 +123,7 @@ safety(Instruction inst) const {
 
 RegisterList SMMLS_cccc01110101ddddaaaammmm11r1nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8), inst(15:12)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -148,7 +148,7 @@ uses(Instruction inst) const {
 //    uses: {Rm, Rn}}
 RegisterList SMMUL_cccc01110101dddd1111mmmm00r1nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -156,7 +156,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SMMUL_cccc01110101dddd1111mmmm00r1nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -175,7 +175,7 @@ safety(Instruction inst) const {
 
 RegisterList SMMUL_cccc01110101dddd1111mmmm00r1nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(11:8), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x00000F00) >> 8))).
@@ -199,7 +199,7 @@ uses(Instruction inst) const {
 //    uses: {Rm, Rn}}
 RegisterList SMUAD_cccc01110000dddd1111mmmm00m1nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -207,7 +207,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SMUAD_cccc01110000dddd1111mmmm00m1nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -226,7 +226,7 @@ safety(Instruction inst) const {
 
 RegisterList SMUAD_cccc01110000dddd1111mmmm00m1nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(11:8), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x00000F00) >> 8))).
@@ -253,7 +253,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SMULBB_SMULBT_SMULTB_SMULTT_cccc00010110dddd0000mmmm1xx0nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -261,7 +261,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SMULBB_SMULBT_SMULTB_SMULTT_cccc00010110dddd0000mmmm1xx0nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -280,7 +280,7 @@ safety(Instruction inst) const {
 
 RegisterList SMULBB_SMULBT_SMULTB_SMULTT_cccc00010110dddd0000mmmm1xx0nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -322,7 +322,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SMULL_A1_cccc0000110shhhhllllmmmm1001nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16), 16
   //       if inst(20)=1
   //       else 32}'
@@ -337,7 +337,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SMULL_A1_cccc0000110shhhhllllmmmm1001nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -375,7 +375,7 @@ safety(Instruction inst) const {
 
 RegisterList SMULL_A1_cccc0000110shhhhllllmmmm1001nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -402,7 +402,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SMULWB_SMULWT_cccc00010010dddd0000mmmm1x10nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -410,7 +410,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SMULWB_SMULWT_cccc00010010dddd0000mmmm1x10nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -429,7 +429,7 @@ safety(Instruction inst) const {
 
 RegisterList SMULWB_SMULWT_cccc00010010dddd0000mmmm1x10nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -453,7 +453,7 @@ uses(Instruction inst) const {
 //    uses: {Rm, Rn}}
 RegisterList SMUSD_cccc01110000dddd1111mmmm01m1nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -461,7 +461,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SMUSD_cccc01110000dddd1111mmmm01m1nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -480,7 +480,7 @@ safety(Instruction inst) const {
 
 RegisterList SMUSD_cccc01110000dddd1111mmmm01m1nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(11:8), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x00000F00) >> 8))).
@@ -498,14 +498,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList SRS_1111100pu1w0110100000101000iiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel SRS_1111100pu1w0110100000101000iiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -517,7 +517,7 @@ safety(Instruction inst) const {
 
 RegisterList SRS_1111100pu1w0110100000101000iiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -539,7 +539,7 @@ uses(Instruction inst) const {
 //    uses: {Rn}}
 RegisterList SSAT16_cccc01101010iiiidddd11110011nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -547,7 +547,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SSAT16_cccc01101010iiiidddd11110011nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -563,7 +563,7 @@ safety(Instruction inst) const {
 
 RegisterList SSAT16_cccc01101010iiiidddd11110011nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -594,7 +594,7 @@ uses(Instruction inst) const {
 //    uses: {Rn}}
 RegisterList SSAT_cccc0110101iiiiiddddiiiiis01nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -602,7 +602,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SSAT_cccc0110101iiiiiddddiiiiis01nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -618,7 +618,7 @@ safety(Instruction inst) const {
 
 RegisterList SSAT_cccc0110101iiiiiddddiiiiis01nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -640,7 +640,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SSAX_cccc01100001nnnndddd11110101mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -648,7 +648,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SSAX_cccc01100001nnnndddd11110101mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -667,7 +667,7 @@ safety(Instruction inst) const {
 
 RegisterList SSAX_cccc01100001nnnndddd11110101mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -690,7 +690,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SSSUB16_cccc01100001nnnndddd11110111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -698,7 +698,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SSSUB16_cccc01100001nnnndddd11110111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -717,7 +717,7 @@ safety(Instruction inst) const {
 
 RegisterList SSSUB16_cccc01100001nnnndddd11110111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -740,7 +740,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SSUB8_cccc01100001nnnndddd11111111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -748,7 +748,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SSUB8_cccc01100001nnnndddd11111111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -767,7 +767,7 @@ safety(Instruction inst) const {
 
 RegisterList SSUB8_cccc01100001nnnndddd11111111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -785,14 +785,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList STC2_1111110pudw0nnnniiiiiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel STC2_1111110pudw0nnnniiiiiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -804,7 +804,7 @@ safety(Instruction inst) const {
 
 RegisterList STC2_1111110pudw0nnnniiiiiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -819,14 +819,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList STC_cccc110pudw0nnnnddddcccciiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel STC_cccc110pudw0nnnnddddcccciiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -838,7 +838,7 @@ safety(Instruction inst) const {
 
 RegisterList STC_cccc110pudw0nnnnddddcccciiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -873,14 +873,14 @@ uses(Instruction inst) const {
 //    wback: W(21)=1}
 Register STMDA_STMED_cccc100000w0nnnnrrrrrrrrrrrrrrrr_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList STMDA_STMED_cccc100000w0nnnnrrrrrrrrrrrrrrrr_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(21)=1
   //       else 32}'
@@ -893,7 +893,7 @@ defs(Instruction inst) const {
 
 SafetyLevel STMDA_STMED_cccc100000w0nnnnrrrrrrrrrrrrrrrr_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -920,7 +920,7 @@ safety(Instruction inst) const {
 bool STMDA_STMED_cccc100000w0nnnnrrrrrrrrrrrrrrrr_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(21)=1'
   return (inst.Bits() & 0x00200000)  ==
           0x00200000;
@@ -928,7 +928,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList STMDA_STMED_cccc100000w0nnnnrrrrrrrrrrrrrrrr_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: 'Union({inst(19:16)}, RegisterList(inst(15:0)))'
   return nacl_arm_dec::Union(RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))), nacl_arm_dec::RegisterList((inst.Bits() & 0x0000FFFF)));
@@ -983,14 +983,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    wback: W(21)=1}
 Register STMDB_STMFD_cccc100100w0nnnnrrrrrrrrrrrrrrrr_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList STMDB_STMFD_cccc100100w0nnnnrrrrrrrrrrrrrrrr_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(21)=1
   //       else 32}'
@@ -1003,7 +1003,7 @@ defs(Instruction inst) const {
 
 SafetyLevel STMDB_STMFD_cccc100100w0nnnnrrrrrrrrrrrrrrrr_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -1030,7 +1030,7 @@ safety(Instruction inst) const {
 bool STMDB_STMFD_cccc100100w0nnnnrrrrrrrrrrrrrrrr_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(21)=1'
   return (inst.Bits() & 0x00200000)  ==
           0x00200000;
@@ -1038,7 +1038,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList STMDB_STMFD_cccc100100w0nnnnrrrrrrrrrrrrrrrr_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: 'Union({inst(19:16)}, RegisterList(inst(15:0)))'
   return nacl_arm_dec::Union(RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))), nacl_arm_dec::RegisterList((inst.Bits() & 0x0000FFFF)));
@@ -1093,14 +1093,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    wback: W(21)=1}
 Register STMIB_STMFA_cccc100110w0nnnnrrrrrrrrrrrrrrrr_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList STMIB_STMFA_cccc100110w0nnnnrrrrrrrrrrrrrrrr_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(21)=1
   //       else 32}'
@@ -1113,7 +1113,7 @@ defs(Instruction inst) const {
 
 SafetyLevel STMIB_STMFA_cccc100110w0nnnnrrrrrrrrrrrrrrrr_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -1140,7 +1140,7 @@ safety(Instruction inst) const {
 bool STMIB_STMFA_cccc100110w0nnnnrrrrrrrrrrrrrrrr_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(21)=1'
   return (inst.Bits() & 0x00200000)  ==
           0x00200000;
@@ -1148,7 +1148,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList STMIB_STMFA_cccc100110w0nnnnrrrrrrrrrrrrrrrr_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: 'Union({inst(19:16)}, RegisterList(inst(15:0)))'
   return nacl_arm_dec::Union(RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))), nacl_arm_dec::RegisterList((inst.Bits() & 0x0000FFFF)));
@@ -1203,14 +1203,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    wback: W(21)=1}
 Register STM_STMIA_STMEA_cccc100010w0nnnnrrrrrrrrrrrrrrrr_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList STM_STMIA_STMEA_cccc100010w0nnnnrrrrrrrrrrrrrrrr_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(21)=1
   //       else 32}'
@@ -1223,7 +1223,7 @@ defs(Instruction inst) const {
 
 SafetyLevel STM_STMIA_STMEA_cccc100010w0nnnnrrrrrrrrrrrrrrrr_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -1250,7 +1250,7 @@ safety(Instruction inst) const {
 bool STM_STMIA_STMEA_cccc100010w0nnnnrrrrrrrrrrrrrrrr_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(21)=1'
   return (inst.Bits() & 0x00200000)  ==
           0x00200000;
@@ -1258,7 +1258,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList STM_STMIA_STMEA_cccc100010w0nnnnrrrrrrrrrrrrrrrr_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: 'Union({inst(19:16)}, RegisterList(inst(15:0)))'
   return nacl_arm_dec::Union(RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))), nacl_arm_dec::RegisterList((inst.Bits() & 0x0000FFFF)));
@@ -1293,14 +1293,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    uses: {}}
 RegisterList STM_User_registers_cccc100pu100nnnnrrrrrrrrrrrrrrrr_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel STM_User_registers_cccc100pu100nnnnrrrrrrrrrrrrrrrr_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -1312,7 +1312,7 @@ safety(Instruction inst) const {
 
 RegisterList STM_User_registers_cccc100pu100nnnnrrrrrrrrrrrrrrrr_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -1327,14 +1327,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList STRBT_A1_cccc0100u110nnnnttttiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel STRBT_A1_cccc0100u110nnnnttttiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -1346,7 +1346,7 @@ safety(Instruction inst) const {
 
 RegisterList STRBT_A1_cccc0100u110nnnnttttiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -1361,14 +1361,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList STRBT_A2_cccc0110u110nnnnttttiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel STRBT_A2_cccc0110u110nnnnttttiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -1380,7 +1380,7 @@ safety(Instruction inst) const {
 
 RegisterList STRBT_A2_cccc0110u110nnnnttttiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -1428,14 +1428,14 @@ uses(Instruction inst) const {
 //         W(21)=1}
 Register STRB_immediate_cccc010pu1w0nnnnttttiiiiiiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList STRB_immediate_cccc010pu1w0nnnnttttiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(24)=0 ||
   //       inst(21)=1
@@ -1451,7 +1451,7 @@ defs(Instruction inst) const {
 
 SafetyLevel STRB_immediate_cccc010pu1w0nnnnttttiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -1487,7 +1487,7 @@ safety(Instruction inst) const {
 bool STRB_immediate_cccc010pu1w0nnnnttttiiiiiiiiiiii_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(24)=0 ||
   //       inst(21)=1'
   return ((inst.Bits() & 0x01000000)  ==
@@ -1498,7 +1498,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList STRB_immediate_cccc010pu1w0nnnnttttiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -1575,14 +1575,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //         W(21)=1}
 Register STRB_register_cccc011pu1w0nnnnttttiiiiitt0mmmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList STRB_register_cccc011pu1w0nnnnttttiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(24)=0 ||
   //       inst(21)=1
@@ -1598,7 +1598,7 @@ defs(Instruction inst) const {
 
 SafetyLevel STRB_register_cccc011pu1w0nnnnttttiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -1655,7 +1655,7 @@ safety(Instruction inst) const {
 
 RegisterList STRB_register_cccc011pu1w0nnnnttttiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(19:16), inst(15:12)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -1737,14 +1737,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //         (W(21)=1)}
 Register STRD_immediate_cccc000pu1w0nnnnttttiiii1111iiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList STRD_immediate_cccc000pu1w0nnnnttttiiii1111iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -1760,7 +1760,7 @@ defs(Instruction inst) const {
 
 SafetyLevel STRD_immediate_cccc000pu1w0nnnnttttiiii1111iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(15:12)(0)=1 => UNPREDICTABLE
   if ((((inst.Bits() & 0x0000F000) >> 12) & 0x00000001)  ==
@@ -1804,7 +1804,7 @@ safety(Instruction inst) const {
 bool STRD_immediate_cccc000pu1w0nnnnttttiiii1111iiii_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(inst(24)=0) ||
   //       (inst(21)=1)'
   return (((inst.Bits() & 0x01000000)  ==
@@ -1815,7 +1815,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList STRD_immediate_cccc000pu1w0nnnnttttiiii1111iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12), inst(15:12) + 1, inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -1895,14 +1895,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //         (W(21)=1)}
 Register STRD_register_cccc000pu0w0nnnntttt00001111mmmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList STRD_register_cccc000pu0w0nnnntttt00001111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -1918,7 +1918,7 @@ defs(Instruction inst) const {
 
 SafetyLevel STRD_register_cccc000pu0w0nnnntttt00001111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(15:12)(0)=1 => UNPREDICTABLE
   if ((((inst.Bits() & 0x0000F000) >> 12) & 0x00000001)  ==
@@ -1983,7 +1983,7 @@ safety(Instruction inst) const {
 
 RegisterList STRD_register_cccc000pu0w0nnnntttt00001111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12), inst(15:12) + 1, inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -2031,14 +2031,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register STREXB_cccc00011100nnnndddd11111001tttt_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList STREXB_cccc00011100nnnndddd11111001tttt_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -2046,7 +2046,7 @@ defs(Instruction inst) const {
 
 SafetyLevel STREXB_cccc00011100nnnndddd11111001tttt_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -2073,7 +2073,7 @@ safety(Instruction inst) const {
 
 RegisterList STREXB_cccc00011100nnnndddd11111001tttt_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -2124,14 +2124,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register STREXD_cccc00011010nnnndddd11111001tttt_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList STREXD_cccc00011010nnnndddd11111001tttt_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -2139,7 +2139,7 @@ defs(Instruction inst) const {
 
 SafetyLevel STREXD_cccc00011010nnnndddd11111001tttt_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -2172,7 +2172,7 @@ safety(Instruction inst) const {
 
 RegisterList STREXD_cccc00011010nnnndddd11111001tttt_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0), inst(3:0) + 1}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -2219,14 +2219,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register STREXH_cccc00011110nnnndddd11111001tttt_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList STREXH_cccc00011110nnnndddd11111001tttt_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -2234,7 +2234,7 @@ defs(Instruction inst) const {
 
 SafetyLevel STREXH_cccc00011110nnnndddd11111001tttt_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -2261,7 +2261,7 @@ safety(Instruction inst) const {
 
 RegisterList STREXH_cccc00011110nnnndddd11111001tttt_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -2305,14 +2305,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register STREXH_cccc00011111nnnntttt111110011111_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList STREXH_cccc00011111nnnntttt111110011111_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -2320,7 +2320,7 @@ defs(Instruction inst) const {
 
 SafetyLevel STREXH_cccc00011111nnnntttt111110011111_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -2336,7 +2336,7 @@ safety(Instruction inst) const {
 
 RegisterList STREXH_cccc00011111nnnntttt111110011111_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -2381,14 +2381,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register STREX_cccc00011000nnnndddd11111001tttt_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList STREX_cccc00011000nnnndddd11111001tttt_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -2396,7 +2396,7 @@ defs(Instruction inst) const {
 
 SafetyLevel STREX_cccc00011000nnnndddd11111001tttt_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -2423,7 +2423,7 @@ safety(Instruction inst) const {
 
 RegisterList STREX_cccc00011000nnnndddd11111001tttt_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -2500,14 +2500,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //         (W(21)=1)}
 Register STRH_immediate_cccc000pu1w0nnnnttttiiii1011iiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList STRH_immediate_cccc000pu1w0nnnnttttiiii1011iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -2523,7 +2523,7 @@ defs(Instruction inst) const {
 
 SafetyLevel STRH_immediate_cccc000pu1w0nnnnttttiiii1011iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -2559,7 +2559,7 @@ safety(Instruction inst) const {
 bool STRH_immediate_cccc000pu1w0nnnnttttiiii1011iiii_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(inst(24)=0) ||
   //       (inst(21)=1)'
   return (((inst.Bits() & 0x01000000)  ==
@@ -2570,7 +2570,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList STRH_immediate_cccc000pu1w0nnnnttttiiii1011iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12), inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -2644,14 +2644,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //         (W(21)=1)}
 Register STRH_register_cccc000pu0w0nnnntttt00001011mmmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList STRH_register_cccc000pu0w0nnnntttt00001011mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if (inst(24)=0) ||
   //       (inst(21)=1)
@@ -2667,7 +2667,7 @@ defs(Instruction inst) const {
 
 SafetyLevel STRH_register_cccc000pu0w0nnnntttt00001011mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -2724,7 +2724,7 @@ safety(Instruction inst) const {
 
 RegisterList STRH_register_cccc000pu0w0nnnntttt00001011mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12), inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -2761,14 +2761,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    uses: {}}
 RegisterList STRT_A1_cccc0100u010nnnnttttiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel STRT_A1_cccc0100u010nnnnttttiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -2780,7 +2780,7 @@ safety(Instruction inst) const {
 
 RegisterList STRT_A1_cccc0100u010nnnnttttiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -2795,14 +2795,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList STRT_A2_cccc0110u010nnnnttttiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel STRT_A2_cccc0110u010nnnnttttiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -2814,7 +2814,7 @@ safety(Instruction inst) const {
 
 RegisterList STRT_A2_cccc0110u010nnnnttttiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -2860,14 +2860,14 @@ uses(Instruction inst) const {
 //         W(21)=1}
 Register STR_immediate_cccc010pu0w0nnnnttttiiiiiiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList STR_immediate_cccc010pu0w0nnnnttttiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(24)=0 ||
   //       inst(21)=1
@@ -2883,7 +2883,7 @@ defs(Instruction inst) const {
 
 SafetyLevel STR_immediate_cccc010pu0w0nnnnttttiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -2914,7 +2914,7 @@ safety(Instruction inst) const {
 bool STR_immediate_cccc010pu0w0nnnnttttiiiiiiiiiiii_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(24)=0 ||
   //       inst(21)=1'
   return ((inst.Bits() & 0x01000000)  ==
@@ -2925,7 +2925,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList STR_immediate_cccc010pu0w0nnnnttttiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -3003,14 +3003,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //         W(21)=1}
 Register STR_register_cccc011pd0w0nnnnttttiiiiitt0mmmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList STR_register_cccc011pd0w0nnnnttttiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(24)=0 ||
   //       inst(21)=1
@@ -3026,7 +3026,7 @@ defs(Instruction inst) const {
 
 SafetyLevel STR_register_cccc011pd0w0nnnnttttiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(21)=1 => DECODER_ERROR
@@ -3080,7 +3080,7 @@ safety(Instruction inst) const {
 
 RegisterList STR_register_cccc011pd0w0nnnnttttiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(19:16), inst(15:12)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -3132,7 +3132,7 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    uses: {Rn}}
 RegisterList SUB_immediate_cccc0010010snnnnddddiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -3146,7 +3146,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SUB_immediate_cccc0010010snnnnddddiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -3175,7 +3175,7 @@ safety(Instruction inst) const {
 
 RegisterList SUB_immediate_cccc0010010snnnnddddiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -3211,7 +3211,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SUB_register_cccc0000010snnnnddddiiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)
   //       else 32}'
@@ -3224,7 +3224,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SUB_register_cccc0000010snnnnddddiiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(15:12)=1111 &&
   //       inst(20)=1) => DECODER_ERROR
@@ -3245,7 +3245,7 @@ safety(Instruction inst) const {
 
 RegisterList SUB_register_cccc0000010snnnnddddiiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -3282,7 +3282,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Rs}}
 RegisterList SUB_register_shifted_register_cccc0000010snnnnddddssss0tt1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), 16
   //       if inst(20)=1
   //       else 32}'
@@ -3296,7 +3296,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SUB_register_shifted_register_cccc0000010snnnnddddssss0tt1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -3318,7 +3318,7 @@ safety(Instruction inst) const {
 
 RegisterList SUB_register_shifted_register_cccc0000010snnnnddddssss0tt1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -3336,14 +3336,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList SVC_cccc1111iiiiiiiiiiiiiiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel SVC_cccc1111iiiiiiiiiiiiiiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -3355,7 +3355,7 @@ safety(Instruction inst) const {
 
 RegisterList SVC_cccc1111iiiiiiiiiiiiiiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3370,14 +3370,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList SWP_SWPB_cccc00010b00nnnntttt00001001tttt_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel SWP_SWPB_cccc00010b00nnnntttt00001001tttt_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => DEPRECATED
   if (true)
@@ -3389,7 +3389,7 @@ safety(Instruction inst) const {
 
 RegisterList SWP_SWPB_cccc00010b00nnnntttt00001001tttt_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3413,7 +3413,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SXTAB16_cccc01101000nnnnddddrr000111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -3421,7 +3421,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SXTAB16_cccc01101000nnnnddddrr000111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:16)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0x000F0000)  ==
@@ -3442,7 +3442,7 @@ safety(Instruction inst) const {
 
 RegisterList SXTAB16_cccc01101000nnnnddddrr000111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -3468,7 +3468,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SXTAB_cccc01101010nnnnddddrr000111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -3476,7 +3476,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SXTAB_cccc01101010nnnnddddrr000111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:16)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0x000F0000)  ==
@@ -3497,7 +3497,7 @@ safety(Instruction inst) const {
 
 RegisterList SXTAB_cccc01101010nnnnddddrr000111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -3523,7 +3523,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList SXTAH_cccc01101011nnnnddddrr000111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -3531,7 +3531,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SXTAH_cccc01101011nnnnddddrr000111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:16)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0x000F0000)  ==
@@ -3552,7 +3552,7 @@ safety(Instruction inst) const {
 
 RegisterList SXTAH_cccc01101011nnnnddddrr000111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -3576,7 +3576,7 @@ uses(Instruction inst) const {
 //    uses: {Rm}}
 RegisterList SXTB16_cccc011010001111ddddrr000111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -3584,7 +3584,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SXTB16_cccc011010001111ddddrr000111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -3600,7 +3600,7 @@ safety(Instruction inst) const {
 
 RegisterList SXTB16_cccc011010001111ddddrr000111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -3623,7 +3623,7 @@ uses(Instruction inst) const {
 //    uses: {Rm}}
 RegisterList SXTB_cccc011010101111ddddrr000111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -3631,7 +3631,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SXTB_cccc011010101111ddddrr000111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -3647,7 +3647,7 @@ safety(Instruction inst) const {
 
 RegisterList SXTB_cccc011010101111ddddrr000111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -3670,7 +3670,7 @@ uses(Instruction inst) const {
 //    uses: {Rm}}
 RegisterList SXTH_cccc011010111111ddddrr000111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -3678,7 +3678,7 @@ defs(Instruction inst) const {
 
 SafetyLevel SXTH_cccc011010111111ddddrr000111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -3694,7 +3694,7 @@ safety(Instruction inst) const {
 
 RegisterList SXTH_cccc011010111111ddddrr000111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -3714,7 +3714,7 @@ uses(Instruction inst) const {
 //    uses: {Rn}}
 RegisterList TEQ_immediate_cccc00110011nnnn0000iiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16}'
   return RegisterList().
    Add(Register(16));
@@ -3722,7 +3722,7 @@ defs(Instruction inst) const {
 
 SafetyLevel TEQ_immediate_cccc00110011nnnn0000iiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -3730,7 +3730,7 @@ safety(Instruction inst) const {
 
 RegisterList TEQ_immediate_cccc00110011nnnn0000iiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -3761,7 +3761,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList TEQ_register_cccc00010011nnnn0000iiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16
   //       if inst(20)
   //       else 32}'
@@ -3773,7 +3773,7 @@ defs(Instruction inst) const {
 
 SafetyLevel TEQ_register_cccc00010011nnnn0000iiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -3781,7 +3781,7 @@ safety(Instruction inst) const {
 
 RegisterList TEQ_register_cccc00010011nnnn0000iiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -3806,7 +3806,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Rs}}
 RegisterList TEQ_register_shifted_register_cccc00010011nnnn0000ssss0tt1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16}'
   return RegisterList().
    Add(Register(16));
@@ -3814,7 +3814,7 @@ defs(Instruction inst) const {
 
 SafetyLevel TEQ_register_shifted_register_cccc00010011nnnn0000ssss0tt1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -3833,7 +3833,7 @@ safety(Instruction inst) const {
 
 RegisterList TEQ_register_shifted_register_cccc00010011nnnn0000ssss0tt1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -3860,7 +3860,7 @@ uses(Instruction inst) const {
 //    uses: {Rn}}
 RegisterList TST_immediate_cccc00110001nnnn0000iiiiiiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16}'
   return RegisterList().
    Add(Register(16));
@@ -3868,7 +3868,7 @@ defs(Instruction inst) const {
 
 SafetyLevel TST_immediate_cccc00110001nnnn0000iiiiiiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -3878,7 +3878,7 @@ bool TST_immediate_cccc00110001nnnn0000iiiiiiiiiiii_case_0::
 sets_Z_if_bits_clear(
       Instruction inst, Register test_register,
       uint32_t clears_mask) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // sets_Z_if_clear_bits: 'RegIndex(test_register())  ==
   //          inst(19:16) &&
   //       (ARMExpandImm_C(inst(11:0)) &&
@@ -3890,7 +3890,7 @@ sets_Z_if_bits_clear(
 
 RegisterList TST_immediate_cccc00110001nnnn0000iiiiiiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -3921,7 +3921,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList TST_register_cccc00010001nnnn0000iiiiitt0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16
   //       if inst(20)
   //       else 32}'
@@ -3933,7 +3933,7 @@ defs(Instruction inst) const {
 
 SafetyLevel TST_register_cccc00010001nnnn0000iiiiitt0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -3941,7 +3941,7 @@ safety(Instruction inst) const {
 
 RegisterList TST_register_cccc00010001nnnn0000iiiiitt0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -3966,7 +3966,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Rs}}
 RegisterList TST_register_shifted_register_cccc00010001nnnn0000ssss0tt1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16}'
   return RegisterList().
    Add(Register(16));
@@ -3974,7 +3974,7 @@ defs(Instruction inst) const {
 
 SafetyLevel TST_register_shifted_register_cccc00010001nnnn0000ssss0tt1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -3993,7 +3993,7 @@ safety(Instruction inst) const {
 
 RegisterList TST_register_shifted_register_cccc00010001nnnn0000ssss0tt1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -4017,7 +4017,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UADD16_cccc01100101nnnndddd11110001mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4025,7 +4025,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UADD16_cccc01100101nnnndddd11110001mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4044,7 +4044,7 @@ safety(Instruction inst) const {
 
 RegisterList UADD16_cccc01100101nnnndddd11110001mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -4067,7 +4067,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UADD8_cccc01100101nnnndddd11111001mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4075,7 +4075,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UADD8_cccc01100101nnnndddd11111001mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4094,7 +4094,7 @@ safety(Instruction inst) const {
 
 RegisterList UADD8_cccc01100101nnnndddd11111001mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -4117,7 +4117,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UASX_cccc01100101nnnndddd11110011mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4125,7 +4125,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UASX_cccc01100101nnnndddd11110011mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4144,7 +4144,7 @@ safety(Instruction inst) const {
 
 RegisterList UASX_cccc01100101nnnndddd11110011mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -4170,7 +4170,7 @@ uses(Instruction inst) const {
 //    widthm1: widthm1(20:16)}
 RegisterList UBFX_cccc0111111mmmmmddddlllll101nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4178,7 +4178,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UBFX_cccc0111111mmmmmddddlllll101nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4199,7 +4199,7 @@ safety(Instruction inst) const {
 
 RegisterList UBFX_cccc0111111mmmmmddddlllll101nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -4215,14 +4215,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList UDF_cccc01111111iiiiiiiiiiii1111iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel UDF_cccc01111111iiiiiiiiiiii1111iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // not IsUDFNaClSafe(inst) => FORBIDDEN_OPERANDS
   if (!(nacl_arm_dec::IsUDFNaClSafe(inst.Bits())))
@@ -4234,7 +4234,7 @@ safety(Instruction inst) const {
 
 RegisterList UDF_cccc01111111iiiiiiiiiiii1111iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4256,7 +4256,7 @@ uses(Instruction inst) const {
 //    uses: {Rm, Rn}}
 RegisterList UDIV_cccc01110011dddd1111mmmm0001nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -4264,7 +4264,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UDIV_cccc01110011dddd1111mmmm0001nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -4283,7 +4283,7 @@ safety(Instruction inst) const {
 
 RegisterList UDIV_cccc01110011dddd1111mmmm0001nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(11:8), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x00000F00) >> 8))).
@@ -4306,7 +4306,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UHADD16_cccc01100111nnnndddd11110001mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4314,7 +4314,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UHADD16_cccc01100111nnnndddd11110001mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4333,7 +4333,7 @@ safety(Instruction inst) const {
 
 RegisterList UHADD16_cccc01100111nnnndddd11110001mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -4356,7 +4356,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UHADD8_cccc01100111nnnndddd11111001mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4364,7 +4364,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UHADD8_cccc01100111nnnndddd11111001mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4383,7 +4383,7 @@ safety(Instruction inst) const {
 
 RegisterList UHADD8_cccc01100111nnnndddd11111001mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -4406,7 +4406,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UHASX_cccc01100111nnnndddd11110011mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4414,7 +4414,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UHASX_cccc01100111nnnndddd11110011mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4433,7 +4433,7 @@ safety(Instruction inst) const {
 
 RegisterList UHASX_cccc01100111nnnndddd11110011mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -4456,7 +4456,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UHSAX_cccc01100111nnnndddd11110101mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4464,7 +4464,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UHSAX_cccc01100111nnnndddd11110101mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4483,7 +4483,7 @@ safety(Instruction inst) const {
 
 RegisterList UHSAX_cccc01100111nnnndddd11110101mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -4506,7 +4506,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UHSUB16_cccc01100111nnnndddd11110111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4514,7 +4514,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UHSUB16_cccc01100111nnnndddd11110111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4533,7 +4533,7 @@ safety(Instruction inst) const {
 
 RegisterList UHSUB16_cccc01100111nnnndddd11110111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -4556,7 +4556,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UHSUB8_cccc01100111nnnndddd11111111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4564,7 +4564,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UHSUB8_cccc01100111nnnndddd11111111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4583,7 +4583,7 @@ safety(Instruction inst) const {
 
 RegisterList UHSUB8_cccc01100111nnnndddd11111111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -4608,7 +4608,7 @@ uses(Instruction inst) const {
 //    uses: {RdLo, RdHi, Rn, Rm}}
 RegisterList UMAAL_A1_cccc00000100hhhhllllmmmm1001nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -4617,7 +4617,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UMAAL_A1_cccc00000100hhhhllllmmmm1001nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4644,7 +4644,7 @@ safety(Instruction inst) const {
 
 RegisterList UMAAL_A1_cccc00000100hhhhllllmmmm1001nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12), inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -4688,7 +4688,7 @@ uses(Instruction inst) const {
 //    uses: {RdLo, RdHi, Rn, Rm}}
 RegisterList UMLAL_A1_cccc0000101shhhhllllmmmm1001nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16), 16
   //       if inst(20)=1
   //       else 32}'
@@ -4703,7 +4703,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UMLAL_A1_cccc0000101shhhhllllmmmm1001nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4741,7 +4741,7 @@ safety(Instruction inst) const {
 
 RegisterList UMLAL_A1_cccc0000101shhhhllllmmmm1001nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12), inst(19:16), inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12))).
@@ -4785,7 +4785,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UMULL_A1_cccc0000100shhhhllllmmmm1001nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16), 16
   //       if inst(20)=1
   //       else 32}'
@@ -4800,7 +4800,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UMULL_A1_cccc0000100shhhhllllmmmm1001nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4838,7 +4838,7 @@ safety(Instruction inst) const {
 
 RegisterList UMULL_A1_cccc0000100shhhhllllmmmm1001nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -4861,7 +4861,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UQADD16_cccc01100110nnnndddd11110001mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4869,7 +4869,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UQADD16_cccc01100110nnnndddd11110001mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4888,7 +4888,7 @@ safety(Instruction inst) const {
 
 RegisterList UQADD16_cccc01100110nnnndddd11110001mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -4911,7 +4911,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UQADD8_cccc01100110nnnndddd11111001mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4919,7 +4919,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UQADD8_cccc01100110nnnndddd11111001mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4938,7 +4938,7 @@ safety(Instruction inst) const {
 
 RegisterList UQADD8_cccc01100110nnnndddd11111001mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -4961,7 +4961,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UQASX_cccc01100110nnnndddd11110011mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4969,7 +4969,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UQASX_cccc01100110nnnndddd11110011mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4988,7 +4988,7 @@ safety(Instruction inst) const {
 
 RegisterList UQASX_cccc01100110nnnndddd11110011mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -5011,7 +5011,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UQSAX_cccc01100110nnnndddd11110101mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5019,7 +5019,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UQSAX_cccc01100110nnnndddd11110101mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -5038,7 +5038,7 @@ safety(Instruction inst) const {
 
 RegisterList UQSAX_cccc01100110nnnndddd11110101mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -5061,7 +5061,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UQSUB16_cccc01100110nnnndddd11110111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5069,7 +5069,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UQSUB16_cccc01100110nnnndddd11110111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -5088,7 +5088,7 @@ safety(Instruction inst) const {
 
 RegisterList UQSUB16_cccc01100110nnnndddd11110111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -5111,7 +5111,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UQSUB8_cccc01100110nnnndddd11111111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5119,7 +5119,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UQSUB8_cccc01100110nnnndddd11111111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -5138,7 +5138,7 @@ safety(Instruction inst) const {
 
 RegisterList UQSUB8_cccc01100110nnnndddd11111111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -5161,7 +5161,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList USAD8_cccc01111000dddd1111mmmm0001nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -5169,7 +5169,7 @@ defs(Instruction inst) const {
 
 SafetyLevel USAD8_cccc01111000dddd1111mmmm0001nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) ||
@@ -5188,7 +5188,7 @@ safety(Instruction inst) const {
 
 RegisterList USAD8_cccc01111000dddd1111mmmm0001nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -5214,7 +5214,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm, Ra}}
 RegisterList USADA8_cccc01111000ddddaaaammmm0001nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -5222,7 +5222,7 @@ defs(Instruction inst) const {
 
 SafetyLevel USADA8_cccc01111000ddddaaaammmm0001nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) => DECODER_ERROR
@@ -5246,7 +5246,7 @@ safety(Instruction inst) const {
 
 RegisterList USADA8_cccc01111000ddddaaaammmm0001nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0), inst(11:8), inst(15:12)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F))).
@@ -5271,7 +5271,7 @@ uses(Instruction inst) const {
 //    uses: {Rn}}
 RegisterList USAT16_cccc01101110iiiidddd11110011nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5279,7 +5279,7 @@ defs(Instruction inst) const {
 
 SafetyLevel USAT16_cccc01101110iiiidddd11110011nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -5295,7 +5295,7 @@ safety(Instruction inst) const {
 
 RegisterList USAT16_cccc01101110iiiidddd11110011nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -5326,7 +5326,7 @@ uses(Instruction inst) const {
 //    uses: {Rn}}
 RegisterList USAT_cccc0110111iiiiiddddiiiiis01nnnn_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5334,7 +5334,7 @@ defs(Instruction inst) const {
 
 SafetyLevel USAT_cccc0110111iiiiiddddiiiiis01nnnn_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -5350,7 +5350,7 @@ safety(Instruction inst) const {
 
 RegisterList USAT_cccc0110111iiiiiddddiiiiis01nnnn_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -5372,7 +5372,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList USAX_cccc01100101nnnndddd11110101mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5380,7 +5380,7 @@ defs(Instruction inst) const {
 
 SafetyLevel USAX_cccc01100101nnnndddd11110101mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -5399,7 +5399,7 @@ safety(Instruction inst) const {
 
 RegisterList USAX_cccc01100101nnnndddd11110101mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -5422,7 +5422,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList USUB16_cccc01100101nnnndddd11110111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5430,7 +5430,7 @@ defs(Instruction inst) const {
 
 SafetyLevel USUB16_cccc01100101nnnndddd11110111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -5449,7 +5449,7 @@ safety(Instruction inst) const {
 
 RegisterList USUB16_cccc01100101nnnndddd11110111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -5472,7 +5472,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList USUB8_cccc01100101nnnndddd11111111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5480,7 +5480,7 @@ defs(Instruction inst) const {
 
 SafetyLevel USUB8_cccc01100101nnnndddd11111111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -5499,7 +5499,7 @@ safety(Instruction inst) const {
 
 RegisterList USUB8_cccc01100101nnnndddd11111111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -5525,7 +5525,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UXTAB16_cccc01101100nnnnddddrr000111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5533,7 +5533,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UXTAB16_cccc01101100nnnnddddrr000111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:16)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0x000F0000)  ==
@@ -5554,7 +5554,7 @@ safety(Instruction inst) const {
 
 RegisterList UXTAB16_cccc01101100nnnnddddrr000111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -5580,7 +5580,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UXTAB_cccc01101110nnnnddddrr000111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5588,7 +5588,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UXTAB_cccc01101110nnnnddddrr000111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:16)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0x000F0000)  ==
@@ -5609,7 +5609,7 @@ safety(Instruction inst) const {
 
 RegisterList UXTAB_cccc01101110nnnnddddrr000111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -5635,7 +5635,7 @@ uses(Instruction inst) const {
 //    uses: {Rn, Rm}}
 RegisterList UXTAH_cccc01101111nnnnddddrr000111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5643,7 +5643,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UXTAH_cccc01101111nnnnddddrr000111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:16)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0x000F0000)  ==
@@ -5664,7 +5664,7 @@ safety(Instruction inst) const {
 
 RegisterList UXTAH_cccc01101111nnnnddddrr000111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16), inst(3:0)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16))).
@@ -5688,7 +5688,7 @@ uses(Instruction inst) const {
 //    uses: {Rm}}
 RegisterList UXTB16_cccc011011001111ddddrr000111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5696,7 +5696,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UXTB16_cccc011011001111ddddrr000111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -5712,7 +5712,7 @@ safety(Instruction inst) const {
 
 RegisterList UXTB16_cccc011011001111ddddrr000111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -5735,7 +5735,7 @@ uses(Instruction inst) const {
 //    uses: {Rm}}
 RegisterList UXTB_cccc011011101111ddddrr000111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5743,7 +5743,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UXTB_cccc011011101111ddddrr000111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -5759,7 +5759,7 @@ safety(Instruction inst) const {
 
 RegisterList UXTB_cccc011011101111ddddrr000111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -5782,7 +5782,7 @@ uses(Instruction inst) const {
 //    uses: {Rm}}
 RegisterList UXTH_cccc011011111111ddddrr000111mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -5790,7 +5790,7 @@ defs(Instruction inst) const {
 
 SafetyLevel UXTH_cccc011011111111ddddrr000111mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -5806,7 +5806,7 @@ safety(Instruction inst) const {
 
 RegisterList UXTH_cccc011011111111ddddrr000111mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)}'
   return RegisterList().
    Add(Register((inst.Bits() & 0x0000000F)));
@@ -5822,14 +5822,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList Unnamed_11110100x001xxxxxxxxxxxxxxxxxxxx_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Unnamed_11110100x001xxxxxxxxxxxxxxxxxxxx_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -5841,7 +5841,7 @@ safety(Instruction inst) const {
 
 RegisterList Unnamed_11110100x001xxxxxxxxxxxxxxxxxxxx_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5855,14 +5855,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList Unnamed_11110100xx11xxxxxxxxxxxxxxxxxxxx_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Unnamed_11110100xx11xxxxxxxxxxxxxxxxxxxx_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => UNPREDICTABLE
   if (true)
@@ -5874,7 +5874,7 @@ safety(Instruction inst) const {
 
 RegisterList Unnamed_11110100xx11xxxxxxxxxxxxxxxxxxxx_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5888,14 +5888,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList Unnamed_111101010011xxxxxxxxxxxxxxxxxxxx_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Unnamed_111101010011xxxxxxxxxxxxxxxxxxxx_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => UNPREDICTABLE
   if (true)
@@ -5907,7 +5907,7 @@ safety(Instruction inst) const {
 
 RegisterList Unnamed_111101010011xxxxxxxxxxxxxxxxxxxx_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5921,14 +5921,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList Unnamed_111101010111xxxxxxxxxxxx0000xxxx_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Unnamed_111101010111xxxxxxxxxxxx0000xxxx_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => UNPREDICTABLE
   if (true)
@@ -5940,7 +5940,7 @@ safety(Instruction inst) const {
 
 RegisterList Unnamed_111101010111xxxxxxxxxxxx0000xxxx_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5954,14 +5954,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList Unnamed_111101010111xxxxxxxxxxxx001xxxxx_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Unnamed_111101010111xxxxxxxxxxxx001xxxxx_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => UNPREDICTABLE
   if (true)
@@ -5973,7 +5973,7 @@ safety(Instruction inst) const {
 
 RegisterList Unnamed_111101010111xxxxxxxxxxxx001xxxxx_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5987,14 +5987,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList Unnamed_111101010111xxxxxxxxxxxx0111xxxx_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Unnamed_111101010111xxxxxxxxxxxx0111xxxx_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => UNPREDICTABLE
   if (true)
@@ -6006,7 +6006,7 @@ safety(Instruction inst) const {
 
 RegisterList Unnamed_111101010111xxxxxxxxxxxx0111xxxx_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6020,14 +6020,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList Unnamed_111101010111xxxxxxxxxxxx1xxxxxxx_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Unnamed_111101010111xxxxxxxxxxxx1xxxxxxx_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => UNPREDICTABLE
   if (true)
@@ -6039,7 +6039,7 @@ safety(Instruction inst) const {
 
 RegisterList Unnamed_111101010111xxxxxxxxxxxx1xxxxxxx_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6053,14 +6053,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList Unnamed_111101011x11xxxxxxxxxxxxxxxxxxxx_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Unnamed_111101011x11xxxxxxxxxxxxxxxxxxxx_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => UNPREDICTABLE
   if (true)
@@ -6072,7 +6072,7 @@ safety(Instruction inst) const {
 
 RegisterList Unnamed_111101011x11xxxxxxxxxxxxxxxxxxxx_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6086,14 +6086,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList Unnamed_11110101x001xxxxxxxxxxxxxxxxxxxx_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Unnamed_11110101x001xxxxxxxxxxxxxxxxxxxx_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => UNPREDICTABLE
   if (true)
@@ -6105,7 +6105,7 @@ safety(Instruction inst) const {
 
 RegisterList Unnamed_11110101x001xxxxxxxxxxxxxxxxxxxx_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6120,14 +6120,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList Unnamed_11110110x001xxxxxxxxxxxxxxx0xxxx_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Unnamed_11110110x001xxxxxxxxxxxxxxx0xxxx_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -6139,7 +6139,7 @@ safety(Instruction inst) const {
 
 RegisterList Unnamed_11110110x001xxxxxxxxxxxxxxx0xxxx_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6153,14 +6153,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList Unnamed_1111011xxx11xxxxxxxxxxxxxxx0xxxx_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Unnamed_1111011xxx11xxxxxxxxxxxxxxx0xxxx_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => UNPREDICTABLE
   if (true)
@@ -6172,7 +6172,7 @@ safety(Instruction inst) const {
 
 RegisterList Unnamed_1111011xxx11xxxxxxxxxxxxxxx0xxxx_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6185,14 +6185,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList Unnamed_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Unnamed_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -6204,7 +6204,7 @@ safety(Instruction inst) const {
 
 RegisterList Unnamed_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6217,14 +6217,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList Unnamed_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Unnamed_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => UNDEFINED
   if (true)
@@ -6236,7 +6236,7 @@ safety(Instruction inst) const {
 
 RegisterList Unnamed_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6250,14 +6250,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList Unnamed_cccc00000101xxxxxxxxxxxx1001xxxx_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Unnamed_cccc00000101xxxxxxxxxxxx1001xxxx_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => UNDEFINED
   if (true)
@@ -6269,7 +6269,7 @@ safety(Instruction inst) const {
 
 RegisterList Unnamed_cccc00000101xxxxxxxxxxxx1001xxxx_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6283,14 +6283,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList Unnamed_cccc00000111xxxxxxxxxxxx1001xxxx_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Unnamed_cccc00000111xxxxxxxxxxxx1001xxxx_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => UNDEFINED
   if (true)
@@ -6302,7 +6302,7 @@ safety(Instruction inst) const {
 
 RegisterList Unnamed_cccc00000111xxxxxxxxxxxx1001xxxx_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6316,14 +6316,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList Unnamed_cccc1100000xnnnnxxxxccccxxxoxxxx_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel Unnamed_cccc1100000xnnnnxxxxccccxxxoxxxx_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => UNDEFINED
   if (true)
@@ -6335,7 +6335,7 @@ safety(Instruction inst) const {
 
 RegisterList Unnamed_cccc1100000xnnnnxxxxccccxxxoxxxx_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6373,14 +6373,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VABAL_A2_1111001u1dssnnnndddd0101n0m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VABAL_A2_1111001u1dssnnnndddd0101n0m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -6398,7 +6398,7 @@ safety(Instruction inst) const {
 
 RegisterList VABAL_A2_1111001u1dssnnnndddd0101n0m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6446,14 +6446,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VABA_1111001u0dssnnnndddd0111nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VABA_1111001u0dssnnnndddd0111nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -6480,7 +6480,7 @@ safety(Instruction inst) const {
 
 RegisterList VABA_1111001u0dssnnnndddd0111nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6518,14 +6518,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VABDL_integer_A2_1111001u1dssnnnndddd0111n0m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VABDL_integer_A2_1111001u1dssnnnndddd0111n0m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -6543,7 +6543,7 @@ safety(Instruction inst) const {
 
 RegisterList VABDL_integer_A2_1111001u1dssnnnndddd0111n0m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6591,14 +6591,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VABD_1111001u0dssnnnndddd0111nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VABD_1111001u0dssnnnndddd0111nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -6625,7 +6625,7 @@ safety(Instruction inst) const {
 
 RegisterList VABD_1111001u0dssnnnndddd0111nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6671,14 +6671,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VABD_floating_point_111100110d1snnnndddd1101nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VABD_floating_point_111100110d1snnnndddd1101nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -6705,7 +6705,7 @@ safety(Instruction inst) const {
 
 RegisterList VABD_floating_point_111100110d1snnnndddd1101nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6746,14 +6746,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VABS_A1_111100111d11ss01dddd0f110qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VABS_A1_111100111d11ss01dddd0f110qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=11 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  ==
@@ -6777,7 +6777,7 @@ safety(Instruction inst) const {
 
 RegisterList VABS_A1_111100111d11ss01dddd0f110qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6818,14 +6818,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VABS_A1_111100111d11ss01dddd0f110qm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VABS_A1_111100111d11ss01dddd0f110qm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -6849,7 +6849,7 @@ safety(Instruction inst) const {
 
 RegisterList VABS_A1_111100111d11ss01dddd0f110qm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6881,14 +6881,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VABS_cccc11101d110000dddd101s11m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VABS_cccc11101d110000dddd101s11m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => MAY_BE_SAFE
   if (true)
@@ -6900,7 +6900,7 @@ safety(Instruction inst) const {
 
 RegisterList VABS_cccc11101d110000dddd101s11m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6946,14 +6946,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VACGE_111100110dssnnnndddd1110nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VACGE_111100110dssnnnndddd1110nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -6980,7 +6980,7 @@ safety(Instruction inst) const {
 
 RegisterList VACGE_111100110dssnnnndddd1110nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7026,14 +7026,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VACGT_111100110dssnnnndddd1110nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VACGT_111100110dssnnnndddd1110nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -7060,7 +7060,7 @@ safety(Instruction inst) const {
 
 RegisterList VACGT_111100110dssnnnndddd1110nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7100,14 +7100,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VADDHN_111100101dssnnnndddd0100n0m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VADDHN_111100101dssnnnndddd0100n0m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -7128,7 +7128,7 @@ safety(Instruction inst) const {
 
 RegisterList VADDHN_111100101dssnnnndddd0100n0m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7171,14 +7171,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VADDL_VADDW_1111001u1dssnnnndddd000pn0m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VADDL_VADDW_1111001u1dssnnnndddd000pn0m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -7202,7 +7202,7 @@ safety(Instruction inst) const {
 
 RegisterList VADDL_VADDW_1111001u1dssnnnndddd000pn0m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7248,14 +7248,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VADD_floating_point_A1_111100100d0snnnndddd1101nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VADD_floating_point_A1_111100100d0snnnndddd1101nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -7282,7 +7282,7 @@ safety(Instruction inst) const {
 
 RegisterList VADD_floating_point_A1_111100100d0snnnndddd1101nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7325,14 +7325,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VADD_floating_point_cccc11100d11nnnndddd101sn0m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VADD_floating_point_cccc11100d11nnnndddd101sn0m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(31:28)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0xF0000000)  ==
@@ -7345,7 +7345,7 @@ safety(Instruction inst) const {
 
 RegisterList VADD_floating_point_cccc11100d11nnnndddd101sn0m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7392,14 +7392,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VADD_integer_111100100dssnnnndddd1000nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VADD_integer_111100100dssnnnndddd1000nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -7421,7 +7421,7 @@ safety(Instruction inst) const {
 
 RegisterList VADD_integer_111100100dssnnnndddd1000nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7465,14 +7465,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VAND_register_111100100d00nnnndddd0001nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VAND_register_111100100d00nnnndddd0001nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -7494,7 +7494,7 @@ safety(Instruction inst) const {
 
 RegisterList VAND_register_111100100d00nnnndddd0001nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7533,14 +7533,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VBIC_immediate_1111001i1d000mmmddddcccc0q11mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VBIC_immediate_1111001i1d000mmmddddcccc0q11mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(11:8)(0)=0 ||
   //       inst(11:8)(3:2)=11 => DECODER_ERROR
@@ -7564,7 +7564,7 @@ safety(Instruction inst) const {
 
 RegisterList VBIC_immediate_1111001i1d000mmmddddcccc0q11mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7608,14 +7608,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VBIC_register_111100100d01nnnndddd0001nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VBIC_register_111100100d01nnnndddd0001nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -7637,7 +7637,7 @@ safety(Instruction inst) const {
 
 RegisterList VBIC_register_111100100d01nnnndddd0001nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7681,14 +7681,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VBIF_111100110d11nnnndddd0001nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VBIF_111100110d11nnnndddd0001nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -7710,7 +7710,7 @@ safety(Instruction inst) const {
 
 RegisterList VBIF_111100110d11nnnndddd0001nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7754,14 +7754,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VBIT_111100110d10nnnndddd0001nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VBIT_111100110d10nnnndddd0001nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -7783,7 +7783,7 @@ safety(Instruction inst) const {
 
 RegisterList VBIT_111100110d10nnnndddd0001nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7827,14 +7827,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VBSL_111100110d01nnnndddd0001nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VBSL_111100110d01nnnndddd0001nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -7856,7 +7856,7 @@ safety(Instruction inst) const {
 
 RegisterList VBSL_111100110d01nnnndddd0001nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7897,14 +7897,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCEQ_immediate_0_111100111d11ss01dddd0f010qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCEQ_immediate_0_111100111d11ss01dddd0f010qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=11 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  ==
@@ -7928,7 +7928,7 @@ safety(Instruction inst) const {
 
 RegisterList VCEQ_immediate_0_111100111d11ss01dddd0f010qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7969,14 +7969,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCEQ_immediate_0_111100111d11ss01dddd0f010qm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCEQ_immediate_0_111100111d11ss01dddd0f010qm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -8000,7 +8000,7 @@ safety(Instruction inst) const {
 
 RegisterList VCEQ_immediate_0_111100111d11ss01dddd0f010qm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8048,14 +8048,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCEQ_register_A1_111100110dssnnnndddd1000nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCEQ_register_A1_111100110dssnnnndddd1000nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -8082,7 +8082,7 @@ safety(Instruction inst) const {
 
 RegisterList VCEQ_register_A1_111100110dssnnnndddd1000nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8128,14 +8128,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCEQ_register_A2_111100100d0snnnndddd1110nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCEQ_register_A2_111100100d0snnnndddd1110nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -8162,7 +8162,7 @@ safety(Instruction inst) const {
 
 RegisterList VCEQ_register_A2_111100100d0snnnndddd1110nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8203,14 +8203,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCGE_immediate_0_111100111d11ss01dddd0f001qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCGE_immediate_0_111100111d11ss01dddd0f001qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=11 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  ==
@@ -8234,7 +8234,7 @@ safety(Instruction inst) const {
 
 RegisterList VCGE_immediate_0_111100111d11ss01dddd0f001qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8275,14 +8275,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCGE_immediate_0_111100111d11ss01dddd0f001qm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCGE_immediate_0_111100111d11ss01dddd0f001qm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -8306,7 +8306,7 @@ safety(Instruction inst) const {
 
 RegisterList VCGE_immediate_0_111100111d11ss01dddd0f001qm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8354,14 +8354,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCGE_register_A1_1111001u0dssnnnndddd0011nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCGE_register_A1_1111001u0dssnnnndddd0011nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -8388,7 +8388,7 @@ safety(Instruction inst) const {
 
 RegisterList VCGE_register_A1_1111001u0dssnnnndddd0011nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8434,14 +8434,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCGE_register_A2_111100110d0snnnndddd1110nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCGE_register_A2_111100110d0snnnndddd1110nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -8468,7 +8468,7 @@ safety(Instruction inst) const {
 
 RegisterList VCGE_register_A2_111100110d0snnnndddd1110nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8509,14 +8509,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCGT_immediate_0_111100111d11ss01dddd0f000qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCGT_immediate_0_111100111d11ss01dddd0f000qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=11 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  ==
@@ -8540,7 +8540,7 @@ safety(Instruction inst) const {
 
 RegisterList VCGT_immediate_0_111100111d11ss01dddd0f000qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8581,14 +8581,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCGT_immediate_0_111100111d11ss01dddd0f000qm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCGT_immediate_0_111100111d11ss01dddd0f000qm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -8612,7 +8612,7 @@ safety(Instruction inst) const {
 
 RegisterList VCGT_immediate_0_111100111d11ss01dddd0f000qm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8660,14 +8660,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCGT_register_A1_1111001u0dssnnnndddd0011nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCGT_register_A1_1111001u0dssnnnndddd0011nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -8694,7 +8694,7 @@ safety(Instruction inst) const {
 
 RegisterList VCGT_register_A1_1111001u0dssnnnndddd0011nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8740,14 +8740,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCGT_register_A2_111100110d1snnnndddd1110nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCGT_register_A2_111100110d1snnnndddd1110nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -8774,7 +8774,7 @@ safety(Instruction inst) const {
 
 RegisterList VCGT_register_A2_111100110d1snnnndddd1110nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8815,14 +8815,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCLE_immediate_0_111100111d11ss01dddd0f011qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCLE_immediate_0_111100111d11ss01dddd0f011qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=11 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  ==
@@ -8846,7 +8846,7 @@ safety(Instruction inst) const {
 
 RegisterList VCLE_immediate_0_111100111d11ss01dddd0f011qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8887,14 +8887,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCLE_immediate_0_111100111d11ss01dddd0f011qm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCLE_immediate_0_111100111d11ss01dddd0f011qm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -8918,7 +8918,7 @@ safety(Instruction inst) const {
 
 RegisterList VCLE_immediate_0_111100111d11ss01dddd0f011qm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8959,14 +8959,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCLS_111100111d11ss00dddd01000qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCLS_111100111d11ss00dddd01000qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=11 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  ==
@@ -8990,7 +8990,7 @@ safety(Instruction inst) const {
 
 RegisterList VCLS_111100111d11ss00dddd01000qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9031,14 +9031,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCLT_immediate_0_111100111d11ss01dddd0f100qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCLT_immediate_0_111100111d11ss01dddd0f100qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=11 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  ==
@@ -9062,7 +9062,7 @@ safety(Instruction inst) const {
 
 RegisterList VCLT_immediate_0_111100111d11ss01dddd0f100qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9103,14 +9103,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCLT_immediate_0_111100111d11ss01dddd0f100qm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCLT_immediate_0_111100111d11ss01dddd0f100qm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -9134,7 +9134,7 @@ safety(Instruction inst) const {
 
 RegisterList VCLT_immediate_0_111100111d11ss01dddd0f100qm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9175,14 +9175,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCLZ_111100111d11ss00dddd01001qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCLZ_111100111d11ss00dddd01001qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=11 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  ==
@@ -9206,7 +9206,7 @@ safety(Instruction inst) const {
 
 RegisterList VCLZ_111100111d11ss00dddd01001qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9240,14 +9240,14 @@ uses(Instruction inst) const {
 //    with_zero: false}
 RegisterList VCMP_VCMPE_cccc11101d110100dddd101se1m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCMP_VCMPE_cccc11101d110100dddd101se1m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => MAY_BE_SAFE
   if (true)
@@ -9259,7 +9259,7 @@ safety(Instruction inst) const {
 
 RegisterList VCMP_VCMPE_cccc11101d110100dddd101se1m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9287,14 +9287,14 @@ uses(Instruction inst) const {
 //    with_zero: true}
 RegisterList VCMP_VCMPE_cccc11101d110101dddd101se1000000_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCMP_VCMPE_cccc11101d110101dddd101se1000000_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => MAY_BE_SAFE
   if (true)
@@ -9306,7 +9306,7 @@ safety(Instruction inst) const {
 
 RegisterList VCMP_VCMPE_cccc11101d110101dddd101se1000000_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9347,14 +9347,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCNT_111100111d11ss00dddd01010qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCNT_111100111d11ss00dddd01010qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=~00 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  !=
@@ -9378,7 +9378,7 @@ safety(Instruction inst) const {
 
 RegisterList VCNT_111100111d11ss00dddd01010qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9408,14 +9408,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCVTB_VCVTT_cccc11101d11001odddd1010t1m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCVTB_VCVTT_cccc11101d11001odddd1010t1m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => MAY_BE_SAFE
   if (true)
@@ -9427,7 +9427,7 @@ safety(Instruction inst) const {
 
 RegisterList VCVTB_VCVTT_cccc11101d11001odddd1010t1m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9470,14 +9470,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCVT_111100111d11ss11dddd011ppqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCVT_111100111d11ss11dddd011ppqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -9501,7 +9501,7 @@ safety(Instruction inst) const {
 
 RegisterList VCVT_111100111d11ss11dddd011ppqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9552,14 +9552,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCVT_VCVTR_between_floating_point_and_integer_Floating_point_cccc11101d111ooodddd101sp1m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCVT_VCVTR_between_floating_point_and_integer_Floating_point_cccc11101d111ooodddd101sp1m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(18:16)=~000 &&
   //       inst(18:16)=~10x => DECODER_ERROR
@@ -9575,7 +9575,7 @@ safety(Instruction inst) const {
 
 RegisterList VCVT_VCVTR_between_floating_point_and_integer_Floating_point_cccc11101d111ooodddd101sp1m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9605,14 +9605,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCVT_between_double_precision_and_single_precision_cccc11101d110111dddd101s11m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCVT_between_double_precision_and_single_precision_cccc11101d110111dddd101s11m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => MAY_BE_SAFE
   if (true)
@@ -9624,7 +9624,7 @@ safety(Instruction inst) const {
 
 RegisterList VCVT_between_double_precision_and_single_precision_cccc11101d110111dddd101s11m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9671,14 +9671,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCVT_between_floating_point_and_fixed_point_1111001u1diiiiiidddd111p0qm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCVT_between_floating_point_and_fixed_point_1111001u1diiiiiidddd111p0qm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:16)=000xxx => DECODER_ERROR
   if ((inst.Bits() & 0x00380000)  ==
@@ -9707,7 +9707,7 @@ safety(Instruction inst) const {
 
 RegisterList VCVT_between_floating_point_and_fixed_point_1111001u1diiiiiidddd111p0qm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9755,14 +9755,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VCVT_between_floating_point_and_fixed_point_Floating_point_cccc11101d111o1udddd101fx1i0iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VCVT_between_floating_point_and_fixed_point_Floating_point_cccc11101d111o1udddd101fx1i0iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 16
   //       if inst(7)=0
@@ -9780,7 +9780,7 @@ safety(Instruction inst) const {
 
 RegisterList VCVT_between_floating_point_and_fixed_point_Floating_point_cccc11101d111o1udddd101fx1i0iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9823,14 +9823,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VDIV_cccc11101d00nnnndddd101sn0m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VDIV_cccc11101d00nnnndddd101sn0m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(31:28)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0xF0000000)  ==
@@ -9843,7 +9843,7 @@ safety(Instruction inst) const {
 
 RegisterList VDIV_cccc11101d00nnnndddd101sn0m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9900,14 +9900,14 @@ uses(Instruction inst) const {
 //    uses: {Rt}}
 RegisterList VDUP_ARM_core_register_cccc11101bq0ddddtttt1011d0e10000_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VDUP_ARM_core_register_cccc11101bq0ddddtttt1011d0e10000_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 14  !=
   //          inst(31:28) => DEPRECATED
@@ -9938,7 +9938,7 @@ safety(Instruction inst) const {
 
 RegisterList VDUP_ARM_core_register_cccc11101bq0ddddtttt1011d0e10000_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -9988,14 +9988,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VDUP_scalar_111100111d11iiiidddd11000qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VDUP_scalar_111100111d11iiiidddd11000qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:16)=x000 => UNDEFINED
   if ((inst.Bits() & 0x00070000)  ==
@@ -10016,7 +10016,7 @@ safety(Instruction inst) const {
 
 RegisterList VDUP_scalar_111100111d11iiiidddd11000qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10060,14 +10060,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VEOR_111100110d00nnnndddd0001nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VEOR_111100110d00nnnndddd0001nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -10089,7 +10089,7 @@ safety(Instruction inst) const {
 
 RegisterList VEOR_111100110d00nnnndddd0001nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10129,14 +10129,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VEXT_111100101d11nnnnddddiiiinqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VEXT_111100101d11nnnnddddiiiinqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -10166,7 +10166,7 @@ safety(Instruction inst) const {
 
 RegisterList VEXT_111100101d11nnnnddddiiiinqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10212,14 +10212,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VFMA_A1_111100100d00nnnndddd1100nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VFMA_A1_111100100d00nnnndddd1100nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -10246,7 +10246,7 @@ safety(Instruction inst) const {
 
 RegisterList VFMA_A1_111100100d00nnnndddd1100nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10292,14 +10292,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VFMA_VFMS_cccc11101d10nnnndddd101snom0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VFMA_VFMS_cccc11101d10nnnndddd101snom0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(31:28)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0xF0000000)  ==
@@ -10312,7 +10312,7 @@ safety(Instruction inst) const {
 
 RegisterList VFMA_VFMS_cccc11101d10nnnndddd101snom0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10358,14 +10358,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VFMS_A1_111100100d10nnnndddd1100nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VFMS_A1_111100100d10nnnndddd1100nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -10392,7 +10392,7 @@ safety(Instruction inst) const {
 
 RegisterList VFMS_A1_111100100d10nnnndddd1100nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10436,14 +10436,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VFNMA_VFNMS_cccc11101d01nnnndddd101snom0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VFNMA_VFNMS_cccc11101d01nnnndddd101snom0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(31:28)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0xF0000000)  ==
@@ -10456,7 +10456,7 @@ safety(Instruction inst) const {
 
 RegisterList VFNMA_VFNMS_cccc11101d01nnnndddd101snom0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10504,14 +10504,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VHADD_1111001u0dssnnnndddd0000nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VHADD_1111001u0dssnnnndddd0000nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -10538,7 +10538,7 @@ safety(Instruction inst) const {
 
 RegisterList VHADD_1111001u0dssnnnndddd0000nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10586,14 +10586,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VHSUB_1111001u0dssnnnndddd0010nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VHSUB_1111001u0dssnnnndddd0010nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -10620,7 +10620,7 @@ safety(Instruction inst) const {
 
 RegisterList VHSUB_1111001u0dssnnnndddd0010nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }

--- a/src/trusted/validator_arm/gen/arm32_decode_baselines_3.cc
+++ b/src/trusted/validator_arm/gen/arm32_decode_baselines_3.cc
@@ -80,14 +80,14 @@ namespace nacl_arm_dec {
 //            Pc)}
 Register VLD1_multiple_single_elements_111101000d10nnnnddddttttssaammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VLD1_multiple_single_elements_111101000d10nnnnddddttttssaammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -100,7 +100,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VLD1_multiple_single_elements_111101000d10nnnnddddttttssaammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(11:8)=0111 &&
   //       inst(5:4)(1)=1 => UNDEFINED
@@ -175,7 +175,7 @@ safety(Instruction inst) const {
 bool VLD1_multiple_single_elements_111101000d10nnnnddddttttssaammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -189,7 +189,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VLD1_multiple_single_elements_111101000d10nnnnddddttttssaammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -278,14 +278,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //            Pc)}
 Register VLD1_single_element_to_all_lanes_111101001d10nnnndddd1100sstammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VLD1_single_element_to_all_lanes_111101001d10nnnndddd1100sstammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -298,7 +298,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VLD1_single_element_to_all_lanes_111101001d10nnnndddd1100sstammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=11 ||
   //       (inst(7:6)=00 &&
@@ -331,7 +331,7 @@ safety(Instruction inst) const {
 bool VLD1_single_element_to_all_lanes_111101001d10nnnndddd1100sstammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -345,7 +345,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VLD1_single_element_to_all_lanes_111101001d10nnnndddd1100sstammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -460,14 +460,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //            Pc)}
 Register VLD1_single_element_to_one_lane_111101001d10nnnnddddss00aaaammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VLD1_single_element_to_one_lane_111101001d10nnnnddddss00aaaammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -480,7 +480,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VLD1_single_element_to_one_lane_111101001d10nnnnddddss00aaaammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(11:10)=11 => UNDEFINED
   if ((inst.Bits() & 0x00000C00)  ==
@@ -534,7 +534,7 @@ safety(Instruction inst) const {
 bool VLD1_single_element_to_one_lane_111101001d10nnnnddddss00aaaammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -548,7 +548,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VLD1_single_element_to_one_lane_111101001d10nnnnddddss00aaaammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -643,14 +643,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //            Pc)}
 Register VLD2_multiple_2_element_structures_111101000d10nnnnddddttttssaammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VLD2_multiple_2_element_structures_111101000d10nnnnddddttttssaammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -663,7 +663,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VLD2_multiple_2_element_structures_111101000d10nnnnddddttttssaammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=11 => UNDEFINED
   if ((inst.Bits() & 0x000000C0)  ==
@@ -720,7 +720,7 @@ safety(Instruction inst) const {
 bool VLD2_multiple_2_element_structures_111101000d10nnnnddddttttssaammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -734,7 +734,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VLD2_multiple_2_element_structures_111101000d10nnnnddddttttssaammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -822,14 +822,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //            Pc)}
 Register VLD2_single_2_element_structure_to_all_lanes_111101001d10nnnndddd1101sstammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VLD2_single_2_element_structure_to_all_lanes_111101001d10nnnndddd1101sstammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -842,7 +842,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VLD2_single_2_element_structure_to_all_lanes_111101001d10nnnndddd1101sstammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=11 => UNDEFINED
   if ((inst.Bits() & 0x000000C0)  ==
@@ -869,7 +869,7 @@ safety(Instruction inst) const {
 bool VLD2_single_2_element_structure_to_all_lanes_111101001d10nnnndddd1101sstammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -883,7 +883,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VLD2_single_2_element_structure_to_all_lanes_111101001d10nnnndddd1101sstammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -996,14 +996,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //            Pc)}
 Register VLD2_single_2_element_structure_to_one_lane_111101001d10nnnnddddss01aaaammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VLD2_single_2_element_structure_to_one_lane_111101001d10nnnnddddss01aaaammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -1016,7 +1016,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VLD2_single_2_element_structure_to_one_lane_111101001d10nnnnddddss01aaaammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(11:10)=11 => UNDEFINED
   if ((inst.Bits() & 0x00000C00)  ==
@@ -1071,7 +1071,7 @@ safety(Instruction inst) const {
 bool VLD2_single_2_element_structure_to_one_lane_111101001d10nnnnddddss01aaaammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -1085,7 +1085,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VLD2_single_2_element_structure_to_one_lane_111101001d10nnnnddddss01aaaammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -1177,14 +1177,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //            Pc)}
 Register VLD3_multiple_3_element_structures_111101000d10nnnnddddttttssaammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VLD3_multiple_3_element_structures_111101000d10nnnnddddttttssaammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -1197,7 +1197,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VLD3_multiple_3_element_structures_111101000d10nnnnddddttttssaammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=11 ||
   //       inst(5:4)(1)=1 => UNDEFINED
@@ -1240,7 +1240,7 @@ safety(Instruction inst) const {
 bool VLD3_multiple_3_element_structures_111101000d10nnnnddddttttssaammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -1254,7 +1254,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VLD3_multiple_3_element_structures_111101000d10nnnnddddttttssaammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -1342,14 +1342,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //            Pc)}
 Register VLD3_single_3_element_structure_to_all_lanes_111101001d10nnnndddd1110sstammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VLD3_single_3_element_structure_to_all_lanes_111101001d10nnnndddd1110sstammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -1362,7 +1362,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VLD3_single_3_element_structure_to_all_lanes_111101001d10nnnndddd1110sstammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=11 ||
   //       inst(4)=1 => UNDEFINED
@@ -1397,7 +1397,7 @@ safety(Instruction inst) const {
 bool VLD3_single_3_element_structure_to_all_lanes_111101001d10nnnndddd1110sstammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -1411,7 +1411,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VLD3_single_3_element_structure_to_all_lanes_111101001d10nnnndddd1110sstammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -1517,14 +1517,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //            Pc)}
 Register VLD3_single_3_element_structure_to_one_lane_111101001d10nnnnddddss10aaaammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VLD3_single_3_element_structure_to_one_lane_111101001d10nnnnddddss10aaaammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -1537,7 +1537,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VLD3_single_3_element_structure_to_one_lane_111101001d10nnnnddddss10aaaammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(11:10)=11 => UNDEFINED
   if ((inst.Bits() & 0x00000C00)  ==
@@ -1633,7 +1633,7 @@ safety(Instruction inst) const {
 bool VLD3_single_3_element_structure_to_one_lane_111101001d10nnnnddddss10aaaammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -1647,7 +1647,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VLD3_single_3_element_structure_to_one_lane_111101001d10nnnnddddss10aaaammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -1739,14 +1739,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //            Pc)}
 Register VLD4_multiple_4_element_structures_111101000d10nnnnddddttttssaammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VLD4_multiple_4_element_structures_111101000d10nnnnddddttttssaammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -1759,7 +1759,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VLD4_multiple_4_element_structures_111101000d10nnnnddddttttssaammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=11 => UNDEFINED
   if ((inst.Bits() & 0x000000C0)  ==
@@ -1804,7 +1804,7 @@ safety(Instruction inst) const {
 bool VLD4_multiple_4_element_structures_111101000d10nnnnddddttttssaammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -1818,7 +1818,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VLD4_multiple_4_element_structures_111101000d10nnnnddddttttssaammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -1915,14 +1915,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //            Pc)}
 Register VLD4_single_4_element_structure_to_all_lanes_111101001d10nnnndddd1111sstammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VLD4_single_4_element_structure_to_all_lanes_111101001d10nnnndddd1111sstammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -1935,7 +1935,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VLD4_single_4_element_structure_to_all_lanes_111101001d10nnnndddd1111sstammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=11 &&
   //       inst(4)=0 => UNDEFINED
@@ -1975,7 +1975,7 @@ safety(Instruction inst) const {
 bool VLD4_single_4_element_structure_to_all_lanes_111101001d10nnnndddd1111sstammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -1989,7 +1989,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VLD4_single_4_element_structure_to_all_lanes_111101001d10nnnndddd1111sstammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -2104,14 +2104,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //            Pc)}
 Register VLD4_single_4_element_structure_to_one_lane_111101001d10nnnnddddss11aaaammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VLD4_single_4_element_structure_to_one_lane_111101001d10nnnnddddss11aaaammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -2124,7 +2124,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VLD4_single_4_element_structure_to_one_lane_111101001d10nnnnddddss11aaaammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(11:10)=11 => UNDEFINED
   if ((inst.Bits() & 0x00000C00)  ==
@@ -2229,7 +2229,7 @@ safety(Instruction inst) const {
 bool VLD4_single_4_element_structure_to_one_lane_111101001d10nnnnddddss11aaaammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -2243,7 +2243,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VLD4_single_4_element_structure_to_one_lane_111101001d10nnnnddddss11aaaammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -2337,14 +2337,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    wback: W(21)=1}
 Register VLDM_cccc110pudw1nnnndddd1010iiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VLDM_cccc110pudw1nnnndddd1010iiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(21)=1
   //       else 32}'
@@ -2357,7 +2357,7 @@ defs(Instruction inst) const {
 
 bool VLDM_cccc110pudw1nnnndddd1010iiiiiiii_case_0::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: '15  ==
   //          inst(19:16)'
   return ((((inst.Bits() & 0x000F0000) >> 16)) == (15));
@@ -2365,7 +2365,7 @@ is_literal_load(Instruction inst) const {
 
 SafetyLevel VLDM_cccc110pudw1nnnndddd1010iiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(23)=0 &&
@@ -2431,7 +2431,7 @@ safety(Instruction inst) const {
 bool VLDM_cccc110pudw1nnnndddd1010iiiiiiii_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(21)=1'
   return (inst.Bits() & 0x00200000)  ==
           0x00200000;
@@ -2439,7 +2439,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VLDM_cccc110pudw1nnnndddd1010iiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -2534,14 +2534,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    wback: W(21)=1}
 Register VLDM_cccc110pudw1nnnndddd1011iiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VLDM_cccc110pudw1nnnndddd1011iiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(21)=1
   //       else 32}'
@@ -2554,7 +2554,7 @@ defs(Instruction inst) const {
 
 bool VLDM_cccc110pudw1nnnndddd1011iiiiiiii_case_0::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: '15  ==
   //          inst(19:16)'
   return ((((inst.Bits() & 0x000F0000) >> 16)) == (15));
@@ -2562,7 +2562,7 @@ is_literal_load(Instruction inst) const {
 
 SafetyLevel VLDM_cccc110pudw1nnnndddd1011iiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(23)=0 &&
@@ -2643,7 +2643,7 @@ safety(Instruction inst) const {
 bool VLDM_cccc110pudw1nnnndddd1011iiiiiiii_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(21)=1'
   return (inst.Bits() & 0x00200000)  ==
           0x00200000;
@@ -2651,7 +2651,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VLDM_cccc110pudw1nnnndddd1011iiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -2703,21 +2703,21 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register VLDR_cccc1101ud01nnnndddd1010iiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VLDR_cccc1101ud01nnnndddd1010iiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 bool VLDR_cccc1101ud01nnnndddd1010iiiiiiii_case_0::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: '15  ==
   //          inst(19:16)'
   return ((((inst.Bits() & 0x000F0000) >> 16)) == (15));
@@ -2725,7 +2725,7 @@ is_literal_load(Instruction inst) const {
 
 SafetyLevel VLDR_cccc1101ud01nnnndddd1010iiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -2733,7 +2733,7 @@ safety(Instruction inst) const {
 
 RegisterList VLDR_cccc1101ud01nnnndddd1010iiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -2785,21 +2785,21 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register VLDR_cccc1101ud01nnnndddd1011iiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VLDR_cccc1101ud01nnnndddd1011iiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 bool VLDR_cccc1101ud01nnnndddd1011iiiiiiii_case_0::
 is_literal_load(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // is_literal_load: '15  ==
   //          inst(19:16)'
   return ((((inst.Bits() & 0x000F0000) >> 16)) == (15));
@@ -2807,7 +2807,7 @@ is_literal_load(Instruction inst) const {
 
 SafetyLevel VLDR_cccc1101ud01nnnndddd1011iiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -2815,7 +2815,7 @@ safety(Instruction inst) const {
 
 RegisterList VLDR_cccc1101ud01nnnndddd1011iiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -2883,14 +2883,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    uses: {}}
 RegisterList VMAX_1111001u0dssnnnndddd0110nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMAX_1111001u0dssnnnndddd0110nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -2917,7 +2917,7 @@ safety(Instruction inst) const {
 
 RegisterList VMAX_1111001u0dssnnnndddd0110nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -2963,14 +2963,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMAX_floating_point_111100100dssnnnndddd1111nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMAX_floating_point_111100100dssnnnndddd1111nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -2997,7 +2997,7 @@ safety(Instruction inst) const {
 
 RegisterList VMAX_floating_point_111100100dssnnnndddd1111nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3045,14 +3045,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMIN_1111001u0dssnnnndddd0110nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMIN_1111001u0dssnnnndddd0110nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -3079,7 +3079,7 @@ safety(Instruction inst) const {
 
 RegisterList VMIN_1111001u0dssnnnndddd0110nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3125,14 +3125,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMIN_floating_point_111100100dssnnnndddd1111nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMIN_floating_point_111100100dssnnnndddd1111nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -3159,7 +3159,7 @@ safety(Instruction inst) const {
 
 RegisterList VMIN_floating_point_111100100dssnnnndddd1111nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3197,14 +3197,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMLAL_VMLSL_integer_A2_1111001u1dssnnnndddd10p0n0m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMLAL_VMLSL_integer_A2_1111001u1dssnnnndddd10p0n0m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -3222,7 +3222,7 @@ safety(Instruction inst) const {
 
 RegisterList VMLAL_VMLSL_integer_A2_1111001u1dssnnnndddd10p0n0m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3271,14 +3271,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMLAL_by_scalar_A2_1111001u1dssnnnndddd0p10n1m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMLAL_by_scalar_A2_1111001u1dssnnnndddd0p10n1m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -3299,7 +3299,7 @@ safety(Instruction inst) const {
 
 RegisterList VMLAL_by_scalar_A2_1111001u1dssnnnndddd0p10n1m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3345,14 +3345,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMLA_VMLS_floating_point_cccc11100d00nnnndddd101snom0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMLA_VMLS_floating_point_cccc11100d00nnnndddd101snom0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(31:28)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0xF0000000)  ==
@@ -3365,7 +3365,7 @@ safety(Instruction inst) const {
 
 RegisterList VMLA_VMLS_floating_point_cccc11100d00nnnndddd101snom0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3414,14 +3414,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMLA_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMLA_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -3453,7 +3453,7 @@ safety(Instruction inst) const {
 
 RegisterList VMLA_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3505,14 +3505,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMLA_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMLA_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -3541,7 +3541,7 @@ safety(Instruction inst) const {
 
 RegisterList VMLA_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3587,14 +3587,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMLA_floating_point_A1_111100100dpsnnnndddd1101nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMLA_floating_point_A1_111100100dpsnnnndddd1101nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -3621,7 +3621,7 @@ safety(Instruction inst) const {
 
 RegisterList VMLA_floating_point_A1_111100100dpsnnnndddd1101nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3669,14 +3669,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMLA_integer_A1_1111001u0dssnnnndddd1001nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMLA_integer_A1_1111001u0dssnnnndddd1001nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -3703,7 +3703,7 @@ safety(Instruction inst) const {
 
 RegisterList VMLA_integer_A1_1111001u0dssnnnndddd1001nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3752,14 +3752,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMLSL_by_scalar_A2_1111001u1dssnnnndddd0p10n1m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMLSL_by_scalar_A2_1111001u1dssnnnndddd0p10n1m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -3780,7 +3780,7 @@ safety(Instruction inst) const {
 
 RegisterList VMLSL_by_scalar_A2_1111001u1dssnnnndddd0p10n1m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3829,14 +3829,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMLS_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMLS_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -3868,7 +3868,7 @@ safety(Instruction inst) const {
 
 RegisterList VMLS_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -3920,14 +3920,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMLS_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMLS_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -3956,7 +3956,7 @@ safety(Instruction inst) const {
 
 RegisterList VMLS_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4002,14 +4002,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMLS_floating_point_A1_111100100dpsnnnndddd1101nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMLS_floating_point_A1_111100100dpsnnnndddd1101nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -4036,7 +4036,7 @@ safety(Instruction inst) const {
 
 RegisterList VMLS_floating_point_A1_111100100dpsnnnndddd1101nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4084,14 +4084,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMLS_integer_A1_1111001u0dssnnnndddd1001nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMLS_integer_A1_1111001u0dssnnnndddd1001nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -4118,7 +4118,7 @@ safety(Instruction inst) const {
 
 RegisterList VMLS_integer_A1_1111001u0dssnnnndddd1001nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4156,14 +4156,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMOVN_111100111d11ss10dddd001000m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMOVN_111100111d11ss10dddd001000m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=11 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  ==
@@ -4181,7 +4181,7 @@ safety(Instruction inst) const {
 
 RegisterList VMOVN_111100111d11ss10dddd001000m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4229,14 +4229,14 @@ uses(Instruction inst) const {
 //    uses: {Rt}}
 RegisterList VMOV_ARM_core_register_to_scalar_cccc11100ii0ddddtttt1011dii10000_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMOV_ARM_core_register_to_scalar_cccc11100ii0ddddtttt1011dii10000_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(22:21):inst(6:5)(3:0)=0x10 => UNDEFINED
   if (((((((inst.Bits() & 0x00600000) >> 21)) << 2) | ((inst.Bits() & 0x00000060) >> 5)) & 0x0000000B)  ==
@@ -4254,7 +4254,7 @@ safety(Instruction inst) const {
 
 RegisterList VMOV_ARM_core_register_to_scalar_cccc11100ii0ddddtttt1011dii10000_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4286,7 +4286,7 @@ uses(Instruction inst) const {
 //         else None}}
 RegisterList VMOV_between_ARM_core_register_and_single_precision_register_cccc1110000onnnntttt1010n0010000_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)
   //       if inst(20)=1
   //       else 32}'
@@ -4299,7 +4299,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VMOV_between_ARM_core_register_and_single_precision_register_cccc1110000onnnntttt1010n0010000_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) => UNPREDICTABLE
@@ -4312,7 +4312,7 @@ safety(Instruction inst) const {
 
 RegisterList VMOV_between_ARM_core_register_and_single_precision_register_cccc1110000onnnntttt1010n0010000_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12)
   //       if not inst(20)=1
   //       else 32}'
@@ -4349,7 +4349,7 @@ uses(Instruction inst) const {
 //         else None}}
 RegisterList VMOV_between_ARM_core_register_and_single_precision_register_cccc1110000xnnnntttt1010n0010000_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12)
   //       if inst(20)=1
   //       else 32}'
@@ -4362,7 +4362,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VMOV_between_ARM_core_register_and_single_precision_register_cccc1110000xnnnntttt1010n0010000_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) => UNPREDICTABLE
@@ -4375,7 +4375,7 @@ safety(Instruction inst) const {
 
 RegisterList VMOV_between_ARM_core_register_and_single_precision_register_cccc1110000xnnnntttt1010n0010000_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12)
   //       if not inst(20)=1
   //       else 32}'
@@ -4415,7 +4415,7 @@ uses(Instruction inst) const {
 //         else {Rt, Rt2}}
 RegisterList VMOV_between_two_ARM_core_registers_and_a_doubleword_extension_register_cccc1100010otttttttt101100m1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)}
   //       if inst(20)=1
   //       else {}'
@@ -4429,7 +4429,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VMOV_between_two_ARM_core_registers_and_a_doubleword_extension_register_cccc1100010otttttttt101100m1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4453,7 +4453,7 @@ safety(Instruction inst) const {
 
 RegisterList VMOV_between_two_ARM_core_registers_and_a_doubleword_extension_register_cccc1100010otttttttt101100m1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}
   //       if inst(20)=1
   //       else {inst(15:12), inst(19:16)}'
@@ -4496,7 +4496,7 @@ uses(Instruction inst) const {
 //         else {Rt, Rt2}}
 RegisterList VMOV_between_two_ARM_core_registers_and_two_single_precision_registers_cccc1100010otttttttt101000m1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(15:12), inst(19:16)}
   //       if inst(20)=1
   //       else {}'
@@ -4510,7 +4510,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VMOV_between_two_ARM_core_registers_and_two_single_precision_registers_cccc1100010otttttttt101000m1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) ||
@@ -4537,7 +4537,7 @@ safety(Instruction inst) const {
 
 RegisterList VMOV_between_two_ARM_core_registers_and_two_single_precision_registers_cccc1100010otttttttt101000m1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}
   //       if inst(20)=1
   //       else {inst(15:12), inst(19:16)}'
@@ -4588,14 +4588,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMOV_immediate_A1_1111001m1d000mmmddddcccc0qp1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMOV_immediate_A1_1111001m1d000mmmddddcccc0qp1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(5)=0 &&
   //       inst(11:8)(0)=1 &&
@@ -4630,7 +4630,7 @@ safety(Instruction inst) const {
 
 RegisterList VMOV_immediate_A1_1111001m1d000mmmddddcccc0qp1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4667,14 +4667,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMOV_immediate_cccc11101d11iiiidddd101s0000iiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMOV_immediate_cccc11101d11iiiidddd101s0000iiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => MAY_BE_SAFE
   if (true)
@@ -4686,7 +4686,7 @@ safety(Instruction inst) const {
 
 RegisterList VMOV_immediate_cccc11101d11iiiidddd101s0000iiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4719,14 +4719,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMOV_register_cccc11101d110000dddd101s01m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMOV_register_cccc11101d110000dddd101s01m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => MAY_BE_SAFE
   if (true)
@@ -4738,7 +4738,7 @@ safety(Instruction inst) const {
 
 RegisterList VMOV_register_cccc11101d110000dddd101s01m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4760,7 +4760,7 @@ uses(Instruction inst) const {
 //    t: Rt}
 RegisterList VMRS_cccc111011110001tttt101000010000_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{16
   //       if 15  ==
   //          inst(15:12)
@@ -4773,7 +4773,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VMRS_cccc111011110001tttt101000010000_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -4795,14 +4795,14 @@ safety(Instruction inst) const {
 //    uses: {Rt}}
 RegisterList VMSR_cccc111011100001tttt101000010000_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMSR_cccc111011100001tttt101000010000_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(15:12) => UNPREDICTABLE
@@ -4815,7 +4815,7 @@ safety(Instruction inst) const {
 
 RegisterList VMSR_cccc111011100001tttt101000010000_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(15:12)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x0000F000) >> 12)));
@@ -4865,14 +4865,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMULL_by_scalar_A2_1111001u1dssnnnndddd1010n1m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMULL_by_scalar_A2_1111001u1dssnnnndddd1010n1m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -4893,7 +4893,7 @@ safety(Instruction inst) const {
 
 RegisterList VMULL_by_scalar_A2_1111001u1dssnnnndddd1010n1m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4931,14 +4931,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMULL_integer_A2_1111001u1dssnnnndddd11p0n0m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMULL_integer_A2_1111001u1dssnnnndddd11p0n0m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -4956,7 +4956,7 @@ safety(Instruction inst) const {
 
 RegisterList VMULL_integer_A2_1111001u1dssnnnndddd11p0n0m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -4997,14 +4997,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMULL_polynomial_A2_1111001u1dssnnnndddd11p0n0m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMULL_polynomial_A2_1111001u1dssnnnndddd11p0n0m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -5030,7 +5030,7 @@ safety(Instruction inst) const {
 
 RegisterList VMULL_polynomial_A2_1111001u1dssnnnndddd11p0n0m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5079,14 +5079,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMUL_by_scalar_A1_1111001q1dssnnnndddd100fn1m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMUL_by_scalar_A1_1111001q1dssnnnndddd100fn1m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -5118,7 +5118,7 @@ safety(Instruction inst) const {
 
 RegisterList VMUL_by_scalar_A1_1111001q1dssnnnndddd100fn1m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5170,14 +5170,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMUL_by_scalar_A1_1111001q1dssnnnndddd100fn1m0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMUL_by_scalar_A1_1111001q1dssnnnndddd100fn1m0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -5206,7 +5206,7 @@ safety(Instruction inst) const {
 
 RegisterList VMUL_by_scalar_A1_1111001q1dssnnnndddd100fn1m0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5252,14 +5252,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMUL_floating_point_A1_111100110d0snnnndddd1101nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMUL_floating_point_A1_111100110d0snnnndddd1101nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -5286,7 +5286,7 @@ safety(Instruction inst) const {
 
 RegisterList VMUL_floating_point_A1_111100110d0snnnndddd1101nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5329,14 +5329,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMUL_floating_point_cccc11100d10nnnndddd101sn0m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMUL_floating_point_cccc11100d10nnnndddd101sn0m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(31:28)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0xF0000000)  ==
@@ -5349,7 +5349,7 @@ safety(Instruction inst) const {
 
 RegisterList VMUL_floating_point_cccc11100d10nnnndddd101sn0m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5397,14 +5397,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMUL_integer_A1_1111001u0dssnnnndddd1001nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMUL_integer_A1_1111001u0dssnnnndddd1001nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -5431,7 +5431,7 @@ safety(Instruction inst) const {
 
 RegisterList VMUL_integer_A1_1111001u0dssnnnndddd1001nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5480,14 +5480,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMUL_polynomial_A1_1111001u0dssnnnndddd1001nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMUL_polynomial_A1_1111001u0dssnnnndddd1001nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -5514,7 +5514,7 @@ safety(Instruction inst) const {
 
 RegisterList VMUL_polynomial_A1_1111001u0dssnnnndddd1001nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5554,14 +5554,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMVN_immediate_1111001i1d000mmmddddcccc0q11mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMVN_immediate_1111001i1d000mmmddddcccc0q11mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // (inst(11:8)(0)=1 &&
   //       inst(11:8)(3:2)=~11) ||
@@ -5588,7 +5588,7 @@ safety(Instruction inst) const {
 
 RegisterList VMVN_immediate_1111001i1d000mmmddddcccc0q11mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5629,14 +5629,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VMVN_register_111100111d11ss00dddd01011qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VMVN_register_111100111d11ss00dddd01011qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=~00 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  !=
@@ -5660,7 +5660,7 @@ safety(Instruction inst) const {
 
 RegisterList VMVN_register_111100111d11ss00dddd01011qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5701,14 +5701,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VNEG_111100111d11ss01dddd0f111qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VNEG_111100111d11ss01dddd0f111qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=11 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  ==
@@ -5732,7 +5732,7 @@ safety(Instruction inst) const {
 
 RegisterList VNEG_111100111d11ss01dddd0f111qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5773,14 +5773,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VNEG_111100111d11ss01dddd0f111qm0mmmm_case_1::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VNEG_111100111d11ss01dddd0f111qm0mmmm_case_1::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -5804,7 +5804,7 @@ safety(Instruction inst) const {
 
 RegisterList VNEG_111100111d11ss01dddd0f111qm0mmmm_case_1::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5836,14 +5836,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VNEG_cccc11101d110001dddd101s01m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VNEG_cccc11101d110001dddd101s01m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => MAY_BE_SAFE
   if (true)
@@ -5855,7 +5855,7 @@ safety(Instruction inst) const {
 
 RegisterList VNEG_cccc11101d110001dddd101s01m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5903,14 +5903,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VNMLA_VNMLS_cccc11100d01nnnndddd101snom0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VNMLA_VNMLS_cccc11100d01nnnndddd101snom0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(31:28)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0xF0000000)  ==
@@ -5923,7 +5923,7 @@ safety(Instruction inst) const {
 
 RegisterList VNMLA_VNMLS_cccc11100d01nnnndddd101snom0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -5966,14 +5966,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VNMUL_cccc11100d10nnnndddd101sn1m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VNMUL_cccc11100d10nnnndddd101sn1m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(31:28)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0xF0000000)  ==
@@ -5986,7 +5986,7 @@ safety(Instruction inst) const {
 
 RegisterList VNMUL_cccc11100d10nnnndddd101sn1m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6030,14 +6030,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VORN_register_111100100d11nnnndddd0001nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VORN_register_111100100d11nnnndddd0001nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -6059,7 +6059,7 @@ safety(Instruction inst) const {
 
 RegisterList VORN_register_111100100d11nnnndddd0001nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6098,14 +6098,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VORR_immediate_1111001i1d000mmmddddcccc0q01mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VORR_immediate_1111001i1d000mmmddddcccc0q01mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(11:8)(0)=0 ||
   //       inst(11:8)(3:2)=11 => DECODER_ERROR
@@ -6129,7 +6129,7 @@ safety(Instruction inst) const {
 
 RegisterList VORR_immediate_1111001i1d000mmmddddcccc0q01mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6173,14 +6173,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VORR_register_or_VMOV_register_A1_111100100d10nnnndddd0001nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VORR_register_or_VMOV_register_A1_111100100d10nnnndddd0001nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -6202,7 +6202,7 @@ safety(Instruction inst) const {
 
 RegisterList VORR_register_or_VMOV_register_A1_111100100d10nnnndddd0001nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6244,14 +6244,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VPADAL_111100111d11ss00dddd0110pqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VPADAL_111100111d11ss00dddd0110pqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=11 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  ==
@@ -6275,7 +6275,7 @@ safety(Instruction inst) const {
 
 RegisterList VPADAL_111100111d11ss00dddd0110pqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6317,14 +6317,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VPADDL_111100111d11ss00dddd0010pqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VPADDL_111100111d11ss00dddd0010pqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=11 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  ==
@@ -6348,7 +6348,7 @@ safety(Instruction inst) const {
 
 RegisterList VPADDL_111100111d11ss00dddd0010pqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6391,14 +6391,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VPADD_floating_point_111100110d0snnnndddd1101nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VPADD_floating_point_111100110d0snnnndddd1101nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)(0)=1 ||
   //       inst(6)=1 => UNDEFINED
@@ -6414,7 +6414,7 @@ safety(Instruction inst) const {
 
 RegisterList VPADD_floating_point_111100110d0snnnndddd1101nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6455,14 +6455,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VPADD_integer_111100100dssnnnndddd1011n0m1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VPADD_integer_111100100dssnnnndddd1011n0m1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => UNDEFINED
   if ((inst.Bits() & 0x00300000)  ==
@@ -6480,7 +6480,7 @@ safety(Instruction inst) const {
 
 RegisterList VPADD_integer_111100100dssnnnndddd1011n0m1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6523,14 +6523,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VPMAX_111100110dssnnnndddd1111nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VPMAX_111100110dssnnnndddd1111nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)(0)=1 ||
   //       inst(6)=1 => UNDEFINED
@@ -6546,7 +6546,7 @@ safety(Instruction inst) const {
 
 RegisterList VPMAX_111100110dssnnnndddd1111nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6587,14 +6587,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VPMAX_1111001u0dssnnnndddd1010n0m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VPMAX_1111001u0dssnnnndddd1010n0m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => UNDEFINED
   if ((inst.Bits() & 0x00300000)  ==
@@ -6612,7 +6612,7 @@ safety(Instruction inst) const {
 
 RegisterList VPMAX_1111001u0dssnnnndddd1010n0m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6655,14 +6655,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VPMIN_111100110dssnnnndddd1111nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VPMIN_111100110dssnnnndddd1111nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)(0)=1 ||
   //       inst(6)=1 => UNDEFINED
@@ -6678,7 +6678,7 @@ safety(Instruction inst) const {
 
 RegisterList VPMIN_111100110dssnnnndddd1111nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6719,14 +6719,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VPMIN_1111001u0dssnnnndddd1010n0m1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VPMIN_1111001u0dssnnnndddd1010n0m1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => UNDEFINED
   if ((inst.Bits() & 0x00300000)  ==
@@ -6744,7 +6744,7 @@ safety(Instruction inst) const {
 
 RegisterList VPMIN_1111001u0dssnnnndddd1010n0m1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -6776,14 +6776,14 @@ uses(Instruction inst) const {
 //    violations: [implied by 'base']}
 Register VPOP_cccc11001d111101dddd1010iiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: '13'
   return Register(13);
 }
 
 RegisterList VPOP_cccc11001d111101dddd1010iiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{13}'
   return RegisterList().
    Add(Register(13));
@@ -6791,7 +6791,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VPOP_cccc11001d111101dddd1010iiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 0  ==
   //          inst(7:0) ||
@@ -6808,14 +6808,14 @@ safety(Instruction inst) const {
 bool VPOP_cccc11001d111101dddd1010iiiiiiii_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'true'
   return true;
 }
 
 RegisterList VPOP_cccc11001d111101dddd1010iiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{13}'
   return RegisterList().
    Add(Register(13));
@@ -6875,14 +6875,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register VPOP_cccc11001d111101dddd1011iiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: '13'
   return Register(13);
 }
 
 RegisterList VPOP_cccc11001d111101dddd1011iiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{13}'
   return RegisterList().
    Add(Register(13));
@@ -6890,7 +6890,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VPOP_cccc11001d111101dddd1011iiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 0  ==
   //          inst(7:0) / 2 ||
@@ -6922,14 +6922,14 @@ safety(Instruction inst) const {
 bool VPOP_cccc11001d111101dddd1011iiiiiiii_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'true'
   return true;
 }
 
 RegisterList VPOP_cccc11001d111101dddd1011iiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{13}'
   return RegisterList().
    Add(Register(13));
@@ -6981,14 +6981,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register VPUSH_cccc11010d101101dddd1010iiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: '13'
   return Register(13);
 }
 
 RegisterList VPUSH_cccc11010d101101dddd1010iiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{13}'
   return RegisterList().
    Add(Register(13));
@@ -6996,7 +6996,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VPUSH_cccc11010d101101dddd1010iiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 0  ==
   //          inst(7:0) ||
@@ -7013,14 +7013,14 @@ safety(Instruction inst) const {
 bool VPUSH_cccc11010d101101dddd1010iiiiiiii_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'true'
   return true;
 }
 
 RegisterList VPUSH_cccc11010d101101dddd1010iiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{13}'
   return RegisterList().
    Add(Register(13));
@@ -7080,14 +7080,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register VPUSH_cccc11010d101101dddd1011iiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: '13'
   return Register(13);
 }
 
 RegisterList VPUSH_cccc11010d101101dddd1011iiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{13}'
   return RegisterList().
    Add(Register(13));
@@ -7095,7 +7095,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VPUSH_cccc11010d101101dddd1011iiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 0  ==
   //          inst(7:0) / 2 ||
@@ -7127,14 +7127,14 @@ safety(Instruction inst) const {
 bool VPUSH_cccc11010d101101dddd1011iiiiiiii_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'true'
   return true;
 }
 
 RegisterList VPUSH_cccc11010d101101dddd1011iiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{13}'
   return RegisterList().
    Add(Register(13));
@@ -7195,14 +7195,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    uses: {}}
 RegisterList VQABS_111100111d11ss00dddd01110qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQABS_111100111d11ss00dddd01110qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=11 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  ==
@@ -7226,7 +7226,7 @@ safety(Instruction inst) const {
 
 RegisterList VQABS_111100111d11ss00dddd01110qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7273,14 +7273,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQADD_1111001u0dssnnnndddd0000nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQADD_1111001u0dssnnnndddd0000nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -7302,7 +7302,7 @@ safety(Instruction inst) const {
 
 RegisterList VQADD_1111001u0dssnnnndddd0000nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7351,14 +7351,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQDMLAL_A1_111100101dssnnnndddd0p11n1m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQDMLAL_A1_111100101dssnnnndddd0p11n1m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -7379,7 +7379,7 @@ safety(Instruction inst) const {
 
 RegisterList VQDMLAL_A1_111100101dssnnnndddd0p11n1m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7422,14 +7422,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQDMLAL_VQDMLSL_A1_111100101dssnnnndddd10p1n0m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQDMLAL_VQDMLSL_A1_111100101dssnnnndddd10p1n0m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -7450,7 +7450,7 @@ safety(Instruction inst) const {
 
 RegisterList VQDMLAL_VQDMLSL_A1_111100101dssnnnndddd10p1n0m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7499,14 +7499,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQDMLSL_A1_111100101dssnnnndddd0p11n1m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQDMLSL_A1_111100101dssnnnndddd0p11n1m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -7527,7 +7527,7 @@ safety(Instruction inst) const {
 
 RegisterList VQDMLSL_A1_111100101dssnnnndddd0p11n1m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7576,14 +7576,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQDMULH_A1_111100100dssnnnndddd1011nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQDMULH_A1_111100100dssnnnndddd1011nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -7613,7 +7613,7 @@ safety(Instruction inst) const {
 
 RegisterList VQDMULH_A1_111100100dssnnnndddd1011nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7665,14 +7665,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQDMULH_A2_1111001q1dssnnnndddd1100n1m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQDMULH_A2_1111001q1dssnnnndddd1100n1m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -7701,7 +7701,7 @@ safety(Instruction inst) const {
 
 RegisterList VQDMULH_A2_1111001q1dssnnnndddd1100n1m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7744,14 +7744,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQDMULL_A1_111100101dssnnnndddd1101n0m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQDMULL_A1_111100101dssnnnndddd1101n0m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -7772,7 +7772,7 @@ safety(Instruction inst) const {
 
 RegisterList VQDMULL_A1_111100101dssnnnndddd1101n0m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7821,14 +7821,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQDMULL_A2_111100101dssnnnndddd1011n1m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQDMULL_A2_111100101dssnnnndddd1011n1m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -7849,7 +7849,7 @@ safety(Instruction inst) const {
 
 RegisterList VQDMULL_A2_111100101dssnnnndddd1011n1m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7877,14 +7877,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQMOVN_111100111d11ss10dddd0010ppm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQMOVN_111100111d11ss10dddd0010ppm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=00 => DECODER_ERROR
   if ((inst.Bits() & 0x000000C0)  ==
@@ -7905,7 +7905,7 @@ safety(Instruction inst) const {
 
 RegisterList VQMOVN_111100111d11ss10dddd0010ppm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -7933,14 +7933,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQMOVUN_111100111d11ss10dddd0010ppm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQMOVUN_111100111d11ss10dddd0010ppm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=00 => DECODER_ERROR
   if ((inst.Bits() & 0x000000C0)  ==
@@ -7961,7 +7961,7 @@ safety(Instruction inst) const {
 
 RegisterList VQMOVUN_111100111d11ss10dddd0010ppm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8002,14 +8002,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQNEG_111100111d11ss00dddd01111qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQNEG_111100111d11ss00dddd01111qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=11 => UNDEFINED
   if ((inst.Bits() & 0x000C0000)  ==
@@ -8033,7 +8033,7 @@ safety(Instruction inst) const {
 
 RegisterList VQNEG_111100111d11ss00dddd01111qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8085,14 +8085,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQRDMULH_1111001q1dssnnnndddd1101n1m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQRDMULH_1111001q1dssnnnndddd1101n1m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -8121,7 +8121,7 @@ safety(Instruction inst) const {
 
 RegisterList VQRDMULH_1111001q1dssnnnndddd1101n1m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8170,14 +8170,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQRDMULH_A1_111100110dssnnnndddd1011nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQRDMULH_A1_111100110dssnnnndddd1011nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -8207,7 +8207,7 @@ safety(Instruction inst) const {
 
 RegisterList VQRDMULH_A1_111100110dssnnnndddd1011nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8254,14 +8254,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQRSHL_1111001u0dssnnnndddd0101nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQRSHL_1111001u0dssnnnndddd0101nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -8283,7 +8283,7 @@ safety(Instruction inst) const {
 
 RegisterList VQRSHL_1111001u0dssnnnndddd0101nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8348,14 +8348,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQRSHRN_1111001u1diiiiiidddd100p01m1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQRSHRN_1111001u1diiiiiidddd100p01m1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:16)=000xxx => DECODER_ERROR
   if ((inst.Bits() & 0x00380000)  ==
@@ -8381,7 +8381,7 @@ safety(Instruction inst) const {
 
 RegisterList VQRSHRN_1111001u1diiiiiidddd100p01m1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8446,14 +8446,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQRSHRUN_1111001u1diiiiiidddd100p00m1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQRSHRUN_1111001u1diiiiiidddd100p00m1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:16)=000xxx => DECODER_ERROR
   if ((inst.Bits() & 0x00380000)  ==
@@ -8479,7 +8479,7 @@ safety(Instruction inst) const {
 
 RegisterList VQRSHRUN_1111001u1diiiiiidddd100p00m1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8544,14 +8544,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQRSHRUN_1111001u1diiiiiidddd100p01m1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQRSHRUN_1111001u1diiiiiidddd100p01m1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:16)=000xxx => DECODER_ERROR
   if ((inst.Bits() & 0x00380000)  ==
@@ -8577,7 +8577,7 @@ safety(Instruction inst) const {
 
 RegisterList VQRSHRUN_1111001u1diiiiiidddd100p01m1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8651,14 +8651,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQSHL_VQSHLU_immediate_1111001u1diiiiiidddd011plqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQSHL_VQSHLU_immediate_1111001u1diiiiiidddd011plqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7):inst(21:16)(6:0)=0000xxx => DECODER_ERROR
   if (((((((inst.Bits() & 0x00000080) >> 7)) << 6) | ((inst.Bits() & 0x003F0000) >> 16)) & 0x00000078)  ==
@@ -8690,7 +8690,7 @@ safety(Instruction inst) const {
 
 RegisterList VQSHL_VQSHLU_immediate_1111001u1diiiiiidddd011plqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8737,14 +8737,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQSHL_register_1111001u0dssnnnndddd0100nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQSHL_register_1111001u0dssnnnndddd0100nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -8766,7 +8766,7 @@ safety(Instruction inst) const {
 
 RegisterList VQSHL_register_1111001u0dssnnnndddd0100nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8831,14 +8831,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQSHRN_1111001u1diiiiiidddd100p00m1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQSHRN_1111001u1diiiiiidddd100p00m1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:16)=000xxx => DECODER_ERROR
   if ((inst.Bits() & 0x00380000)  ==
@@ -8864,7 +8864,7 @@ safety(Instruction inst) const {
 
 RegisterList VQSHRN_1111001u1diiiiiidddd100p00m1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -8929,14 +8929,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQSHRUN_1111001u1diiiiiidddd100p00m1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQSHRUN_1111001u1diiiiiidddd100p00m1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:16)=000xxx => DECODER_ERROR
   if ((inst.Bits() & 0x00380000)  ==
@@ -8962,7 +8962,7 @@ safety(Instruction inst) const {
 
 RegisterList VQSHRUN_1111001u1diiiiiidddd100p00m1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9009,14 +9009,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VQSUB_1111001u0dssnnnndddd0010nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VQSUB_1111001u0dssnnnndddd0010nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -9038,7 +9038,7 @@ safety(Instruction inst) const {
 
 RegisterList VQSUB_1111001u0dssnnnndddd0010nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9078,14 +9078,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VRADDHN_111100111dssnnnndddd0100n0m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VRADDHN_111100111dssnnnndddd0100n0m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -9106,7 +9106,7 @@ safety(Instruction inst) const {
 
 RegisterList VRADDHN_111100111dssnnnndddd0100n0m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9148,14 +9148,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VRECPE_111100111d11ss11dddd010f0qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VRECPE_111100111d11ss11dddd010f0qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -9179,7 +9179,7 @@ safety(Instruction inst) const {
 
 RegisterList VRECPE_111100111d11ss11dddd010f0qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9225,14 +9225,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VRECPS_111100100d0snnnndddd1111nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VRECPS_111100100d0snnnndddd1111nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -9259,7 +9259,7 @@ safety(Instruction inst) const {
 
 RegisterList VRECPS_111100100d0snnnndddd1111nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9303,14 +9303,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VREV16_111100111d11ss00dddd000ppqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VREV16_111100111d11ss00dddd000ppqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 3  <
   //          inst(8:7) + inst(19:18) => UNDEFINED
@@ -9334,7 +9334,7 @@ safety(Instruction inst) const {
 
 RegisterList VREV16_111100111d11ss00dddd000ppqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9378,14 +9378,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VREV32_111100111d11ss00dddd000ppqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VREV32_111100111d11ss00dddd000ppqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 3  <
   //          inst(8:7) + inst(19:18) => UNDEFINED
@@ -9409,7 +9409,7 @@ safety(Instruction inst) const {
 
 RegisterList VREV32_111100111d11ss00dddd000ppqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9453,14 +9453,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VREV64_111100111d11ss00dddd000ppqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VREV64_111100111d11ss00dddd000ppqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 3  <
   //          inst(8:7) + inst(19:18) => UNDEFINED
@@ -9484,7 +9484,7 @@ safety(Instruction inst) const {
 
 RegisterList VREV64_111100111d11ss00dddd000ppqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9532,14 +9532,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VRHADD_1111001u0dssnnnndddd0001nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VRHADD_1111001u0dssnnnndddd0001nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -9566,7 +9566,7 @@ safety(Instruction inst) const {
 
 RegisterList VRHADD_1111001u0dssnnnndddd0001nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9613,14 +9613,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VRSHL_1111001u0dssnnnndddd0101nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VRSHL_1111001u0dssnnnndddd0101nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -9642,7 +9642,7 @@ safety(Instruction inst) const {
 
 RegisterList VRSHL_1111001u0dssnnnndddd0101nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9701,14 +9701,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VRSHRN_111100101diiiiiidddd100001m1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VRSHRN_111100101diiiiiidddd100001m1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:16)=000xxx => DECODER_ERROR
   if ((inst.Bits() & 0x00380000)  ==
@@ -9726,7 +9726,7 @@ safety(Instruction inst) const {
 
 RegisterList VRSHRN_111100101diiiiiidddd100001m1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9791,14 +9791,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VRSHR_1111001u1diiiiiidddd0010lqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VRSHR_1111001u1diiiiiidddd0010lqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7):inst(21:16)(6:0)=0000xxx => DECODER_ERROR
   if (((((((inst.Bits() & 0x00000080) >> 7)) << 6) | ((inst.Bits() & 0x003F0000) >> 16)) & 0x00000078)  ==
@@ -9822,7 +9822,7 @@ safety(Instruction inst) const {
 
 RegisterList VRSHR_1111001u1diiiiiidddd0010lqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9864,14 +9864,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VRSQRTE_111100111d11ss11dddd010f1qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VRSQRTE_111100111d11ss11dddd010f1qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -9895,7 +9895,7 @@ safety(Instruction inst) const {
 
 RegisterList VRSQRTE_111100111d11ss11dddd010f1qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -9941,14 +9941,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VRSQRTS_111100100d1snnnndddd1111nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VRSQRTS_111100100d1snnnndddd1111nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -9975,7 +9975,7 @@ safety(Instruction inst) const {
 
 RegisterList VRSQRTS_111100100d1snnnndddd1111nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10040,14 +10040,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VRSRA_1111001u1diiiiiidddd0011lqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VRSRA_1111001u1diiiiiidddd0011lqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7):inst(21:16)(6:0)=0000xxx => DECODER_ERROR
   if (((((((inst.Bits() & 0x00000080) >> 7)) << 6) | ((inst.Bits() & 0x003F0000) >> 16)) & 0x00000078)  ==
@@ -10071,7 +10071,7 @@ safety(Instruction inst) const {
 
 RegisterList VRSRA_1111001u1diiiiiidddd0011lqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10111,14 +10111,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VRSUBHN_111100111dssnnnndddd0110n0m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VRSUBHN_111100111dssnnnndddd0110n0m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -10139,7 +10139,7 @@ safety(Instruction inst) const {
 
 RegisterList VRSUBHN_111100111dssnnnndddd0110n0m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10198,14 +10198,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VSHLL_A1_or_VMOVL_1111001u1diiiiiidddd101000m1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VSHLL_A1_or_VMOVL_1111001u1diiiiiidddd101000m1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:16)=000xxx => DECODER_ERROR
   if ((inst.Bits() & 0x00380000)  ==
@@ -10223,7 +10223,7 @@ safety(Instruction inst) const {
 
 RegisterList VSHLL_A1_or_VMOVL_1111001u1diiiiiidddd101000m1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10263,14 +10263,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VSHLL_A2_111100111d11ss10dddd001100m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VSHLL_A2_111100111d11ss10dddd001100m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(19:18)=11 ||
   //       inst(15:12)(0)=1 => UNDEFINED
@@ -10286,7 +10286,7 @@ safety(Instruction inst) const {
 
 RegisterList VSHLL_A2_111100111d11ss10dddd001100m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10355,14 +10355,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VSHL_immediate_111100101diiiiiidddd0101lqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VSHL_immediate_111100101diiiiiidddd0101lqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7):inst(21:16)(6:0)=0000xxx => DECODER_ERROR
   if (((((((inst.Bits() & 0x00000080) >> 7)) << 6) | ((inst.Bits() & 0x003F0000) >> 16)) & 0x00000078)  ==
@@ -10386,7 +10386,7 @@ safety(Instruction inst) const {
 
 RegisterList VSHL_immediate_111100101diiiiiidddd0101lqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10433,14 +10433,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VSHL_register_1111001u0dssnnnndddd0100nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VSHL_register_1111001u0dssnnnndddd0100nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -10462,7 +10462,7 @@ safety(Instruction inst) const {
 
 RegisterList VSHL_register_1111001u0dssnnnndddd0100nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10521,14 +10521,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VSHRN_111100101diiiiiidddd100000m1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VSHRN_111100101diiiiiidddd100000m1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:16)=000xxx => DECODER_ERROR
   if ((inst.Bits() & 0x00380000)  ==
@@ -10546,7 +10546,7 @@ safety(Instruction inst) const {
 
 RegisterList VSHRN_111100101diiiiiidddd100000m1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10611,14 +10611,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VSHR_1111001u1diiiiiidddd0000lqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VSHR_1111001u1diiiiiidddd0000lqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7):inst(21:16)(6:0)=0000xxx => DECODER_ERROR
   if (((((((inst.Bits() & 0x00000080) >> 7)) << 6) | ((inst.Bits() & 0x003F0000) >> 16)) & 0x00000078)  ==
@@ -10642,7 +10642,7 @@ safety(Instruction inst) const {
 
 RegisterList VSHR_1111001u1diiiiiidddd0000lqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10711,14 +10711,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VSLI_111100111diiiiiidddd0101lqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VSLI_111100111diiiiiidddd0101lqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7):inst(21:16)(6:0)=0000xxx => DECODER_ERROR
   if (((((((inst.Bits() & 0x00000080) >> 7)) << 6) | ((inst.Bits() & 0x003F0000) >> 16)) & 0x00000078)  ==
@@ -10742,7 +10742,7 @@ safety(Instruction inst) const {
 
 RegisterList VSLI_111100111diiiiiidddd0101lqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10774,14 +10774,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VSQRT_cccc11101d110001dddd101s11m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VSQRT_cccc11101d110001dddd101s11m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => MAY_BE_SAFE
   if (true)
@@ -10793,7 +10793,7 @@ safety(Instruction inst) const {
 
 RegisterList VSQRT_cccc11101d110001dddd101s11m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10858,14 +10858,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VSRA_1111001u1diiiiiidddd0001lqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VSRA_1111001u1diiiiiidddd0001lqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7):inst(21:16)(6:0)=0000xxx => DECODER_ERROR
   if (((((((inst.Bits() & 0x00000080) >> 7)) << 6) | ((inst.Bits() & 0x003F0000) >> 16)) & 0x00000078)  ==
@@ -10889,7 +10889,7 @@ safety(Instruction inst) const {
 
 RegisterList VSRA_1111001u1diiiiiidddd0001lqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -10954,14 +10954,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VSRI_111100111diiiiiidddd0100lqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VSRI_111100111diiiiiidddd0100lqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7):inst(21:16)(6:0)=0000xxx => DECODER_ERROR
   if (((((((inst.Bits() & 0x00000080) >> 7)) << 6) | ((inst.Bits() & 0x003F0000) >> 16)) & 0x00000078)  ==
@@ -10985,7 +10985,7 @@ safety(Instruction inst) const {
 
 RegisterList VSRI_111100111diiiiiidddd0100lqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -11059,14 +11059,14 @@ uses(Instruction inst) const {
 //            Pc)}
 Register VST1_multiple_single_elements_111101000d00nnnnddddttttssaammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VST1_multiple_single_elements_111101000d00nnnnddddttttssaammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -11079,7 +11079,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VST1_multiple_single_elements_111101000d00nnnnddddttttssaammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(11:8)=0111 &&
   //       inst(5:4)(1)=1 => UNDEFINED
@@ -11154,7 +11154,7 @@ safety(Instruction inst) const {
 bool VST1_multiple_single_elements_111101000d00nnnnddddttttssaammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -11168,7 +11168,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VST1_multiple_single_elements_111101000d00nnnnddddttttssaammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -11283,14 +11283,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //            Pc)}
 Register VST1_single_element_from_one_lane_111101001d00nnnnddddss00aaaammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VST1_single_element_from_one_lane_111101001d00nnnnddddss00aaaammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -11303,7 +11303,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VST1_single_element_from_one_lane_111101001d00nnnnddddss00aaaammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(11:10)=11 => UNDEFINED
   if ((inst.Bits() & 0x00000C00)  ==
@@ -11357,7 +11357,7 @@ safety(Instruction inst) const {
 bool VST1_single_element_from_one_lane_111101001d00nnnnddddss00aaaammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -11371,7 +11371,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VST1_single_element_from_one_lane_111101001d00nnnnddddss00aaaammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -11466,14 +11466,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //            Pc)}
 Register VST2_multiple_2_element_structures_111101000d00nnnnddddttttssaammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VST2_multiple_2_element_structures_111101000d00nnnnddddttttssaammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -11486,7 +11486,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VST2_multiple_2_element_structures_111101000d00nnnnddddttttssaammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=11 => UNDEFINED
   if ((inst.Bits() & 0x000000C0)  ==
@@ -11543,7 +11543,7 @@ safety(Instruction inst) const {
 bool VST2_multiple_2_element_structures_111101000d00nnnnddddttttssaammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -11557,7 +11557,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VST2_multiple_2_element_structures_111101000d00nnnnddddttttssaammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -11670,14 +11670,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //            Pc)}
 Register VST2_single_2_element_structure_from_one_lane_111101001d00nnnnddddss01aaaammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VST2_single_2_element_structure_from_one_lane_111101001d00nnnnddddss01aaaammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -11690,7 +11690,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VST2_single_2_element_structure_from_one_lane_111101001d00nnnnddddss01aaaammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(11:10)=11 => UNDEFINED
   if ((inst.Bits() & 0x00000C00)  ==
@@ -11745,7 +11745,7 @@ safety(Instruction inst) const {
 bool VST2_single_2_element_structure_from_one_lane_111101001d00nnnnddddss01aaaammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -11759,7 +11759,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VST2_single_2_element_structure_from_one_lane_111101001d00nnnnddddss01aaaammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -11851,14 +11851,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //            Pc)}
 Register VST3_multiple_3_element_structures_111101000d00nnnnddddttttssaammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VST3_multiple_3_element_structures_111101000d00nnnnddddttttssaammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -11871,7 +11871,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VST3_multiple_3_element_structures_111101000d00nnnnddddttttssaammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=11 ||
   //       inst(5:4)(1)=1 => UNDEFINED
@@ -11914,7 +11914,7 @@ safety(Instruction inst) const {
 bool VST3_multiple_3_element_structures_111101000d00nnnnddddttttssaammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -11928,7 +11928,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VST3_multiple_3_element_structures_111101000d00nnnnddddttttssaammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -12034,14 +12034,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //            Pc)}
 Register VST3_single_3_element_structure_from_one_lane_111101001d00nnnnddddss10aaaammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VST3_single_3_element_structure_from_one_lane_111101001d00nnnnddddss10aaaammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -12054,7 +12054,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VST3_single_3_element_structure_from_one_lane_111101001d00nnnnddddss10aaaammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(11:10)=11 => UNDEFINED
   if ((inst.Bits() & 0x00000C00)  ==
@@ -12150,7 +12150,7 @@ safety(Instruction inst) const {
 bool VST3_single_3_element_structure_from_one_lane_111101001d00nnnnddddss10aaaammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -12164,7 +12164,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VST3_single_3_element_structure_from_one_lane_111101001d00nnnnddddss10aaaammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -12256,14 +12256,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //            Pc)}
 Register VST4_multiple_4_element_structures_111101000d00nnnnddddttttssaammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VST4_multiple_4_element_structures_111101000d00nnnnddddttttssaammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -12276,7 +12276,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VST4_multiple_4_element_structures_111101000d00nnnnddddttttssaammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(7:6)=11 => UNDEFINED
   if ((inst.Bits() & 0x000000C0)  ==
@@ -12321,7 +12321,7 @@ safety(Instruction inst) const {
 bool VST4_multiple_4_element_structures_111101000d00nnnnddddttttssaammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -12335,7 +12335,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VST4_multiple_4_element_structures_111101000d00nnnnddddttttssaammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -12450,14 +12450,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //            Pc)}
 Register VST4_single_4_element_structure_form_one_lane_111101001d00nnnnddddss11aaaammmm_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VST4_single_4_element_structure_form_one_lane_111101001d00nnnnddddss11aaaammmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)}
   //       if (15  !=
   //          inst(3:0))
@@ -12470,7 +12470,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VST4_single_4_element_structure_form_one_lane_111101001d00nnnnddddss11aaaammmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(11:10)=11 => UNDEFINED
   if ((inst.Bits() & 0x00000C00)  ==
@@ -12575,7 +12575,7 @@ safety(Instruction inst) const {
 bool VST4_single_4_element_structure_form_one_lane_111101001d00nnnnddddss11aaaammmm_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: '(15  !=
   //          inst(3:0)) &&
   //       not (15  !=
@@ -12589,7 +12589,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VST4_single_4_element_structure_form_one_lane_111101001d00nnnnddddss11aaaammmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(3:0)
   //       if (15  !=
   //          inst(3:0))
@@ -12683,14 +12683,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    wback: W(21)=1}
 Register VSTM_cccc110pudw0nnnndddd1010iiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VSTM_cccc110pudw0nnnndddd1010iiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(21)=1
   //       else 32}'
@@ -12703,7 +12703,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VSTM_cccc110pudw0nnnndddd1010iiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(23)=0 &&
@@ -12774,7 +12774,7 @@ safety(Instruction inst) const {
 bool VSTM_cccc110pudw0nnnndddd1010iiiiiiii_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(21)=1'
   return (inst.Bits() & 0x00200000)  ==
           0x00200000;
@@ -12782,7 +12782,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VSTM_cccc110pudw0nnnndddd1010iiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -12877,14 +12877,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    wback: W(21)=1}
 Register VSTM_cccc110pudw0nnnndddd1011iiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VSTM_cccc110pudw0nnnndddd1011iiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{inst(19:16)
   //       if inst(21)=1
   //       else 32}'
@@ -12897,7 +12897,7 @@ defs(Instruction inst) const {
 
 SafetyLevel VSTM_cccc110pudw0nnnndddd1011iiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(24)=0 &&
   //       inst(23)=0 &&
@@ -12983,7 +12983,7 @@ safety(Instruction inst) const {
 bool VSTM_cccc110pudw0nnnndddd1011iiiiiiii_case_0::
 base_address_register_writeback_small_immediate(
       Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // small_imm_base_wb: 'inst(21)=1'
   return (inst.Bits() & 0x00200000)  ==
           0x00200000;
@@ -12991,7 +12991,7 @@ base_address_register_writeback_small_immediate(
 
 RegisterList VSTM_cccc110pudw0nnnndddd1011iiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -13043,21 +13043,21 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register VSTR_cccc1101ud00nnnndddd1010iiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VSTR_cccc1101ud00nnnndddd1010iiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VSTR_cccc1101ud00nnnndddd1010iiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) => FORBIDDEN_OPERANDS
@@ -13070,7 +13070,7 @@ safety(Instruction inst) const {
 
 RegisterList VSTR_cccc1101ud00nnnndddd1010iiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -13122,21 +13122,21 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    violations: [implied by 'base']}
 Register VSTR_cccc1101ud00nnnndddd1011iiiiiiii_case_0::
 base_address_register(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // base: 'inst(19:16)'
   return Register(((inst.Bits() & 0x000F0000) >> 16));
 }
 
 RegisterList VSTR_cccc1101ud00nnnndddd1011iiiiiiii_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VSTR_cccc1101ud00nnnndddd1011iiiiiiii_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 15  ==
   //          inst(19:16) => FORBIDDEN_OPERANDS
@@ -13149,7 +13149,7 @@ safety(Instruction inst) const {
 
 RegisterList VSTR_cccc1101ud00nnnndddd1011iiiiiiii_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{inst(19:16)}'
   return RegisterList().
    Add(Register(((inst.Bits() & 0x000F0000) >> 16)));
@@ -13209,14 +13209,14 @@ get_violations(const nacl_arm_val::DecodedInstruction& first,
 //    uses: {}}
 RegisterList VSUBHN_111100101dssnnnndddd0110n0m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VSUBHN_111100101dssnnnndddd0110n0m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -13237,7 +13237,7 @@ safety(Instruction inst) const {
 
 RegisterList VSUBHN_111100101dssnnnndddd0110n0m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -13279,14 +13279,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VSUBL_VSUBW_1111001u1dssnnnndddd001pn0m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VSUBL_VSUBW_1111001u1dssnnnndddd001pn0m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(21:20)=11 => DECODER_ERROR
   if ((inst.Bits() & 0x00300000)  ==
@@ -13310,7 +13310,7 @@ safety(Instruction inst) const {
 
 RegisterList VSUBL_VSUBW_1111001u1dssnnnndddd001pn0m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -13356,14 +13356,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VSUB_floating_point_A1_111100100d1snnnndddd1101nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VSUB_floating_point_A1_111100100d1snnnndddd1101nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -13390,7 +13390,7 @@ safety(Instruction inst) const {
 
 RegisterList VSUB_floating_point_A1_111100100d1snnnndddd1101nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -13433,14 +13433,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VSUB_floating_point_cccc11100d11nnnndddd101sn1m0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VSUB_floating_point_cccc11100d11nnnndddd101sn1m0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(31:28)=1111 => DECODER_ERROR
   if ((inst.Bits() & 0xF0000000)  ==
@@ -13453,7 +13453,7 @@ safety(Instruction inst) const {
 
 RegisterList VSUB_floating_point_cccc11100d11nnnndddd101sn1m0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -13500,14 +13500,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VSUB_integer_111100110dssnnnndddd1000nqm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VSUB_integer_111100110dssnnnndddd1000nqm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -13529,7 +13529,7 @@ safety(Instruction inst) const {
 
 RegisterList VSUB_integer_111100110dssnnnndddd1000nqm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -13572,14 +13572,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VSWP_111100111d11ss10dddd00000qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VSWP_111100111d11ss10dddd00000qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(22):inst(15:12)  ==
   //          inst(5):inst(3:0) => UNKNOWN
@@ -13608,7 +13608,7 @@ safety(Instruction inst) const {
 
 RegisterList VSWP_111100111d11ss10dddd00000qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -13644,14 +13644,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VTBL_VTBX_111100111d11nnnndddd10ccnpm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VTBL_VTBX_111100111d11nnnndddd10ccnpm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // 32  <=
   //          inst(7):inst(19:16) + inst(9:8) + 1 => UNPREDICTABLE
@@ -13664,7 +13664,7 @@ safety(Instruction inst) const {
 
 RegisterList VTBL_VTBX_111100111d11nnnndddd10ccnpm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -13708,14 +13708,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VTRN_111100111d11ss10dddd00001qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VTRN_111100111d11ss10dddd00001qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(22):inst(15:12)  ==
   //          inst(5):inst(3:0) => UNKNOWN
@@ -13744,7 +13744,7 @@ safety(Instruction inst) const {
 
 RegisterList VTRN_111100111d11ss10dddd00001qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -13792,14 +13792,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VTST_111100100dssnnnndddd1000nqm1mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VTST_111100100dssnnnndddd1000nqm1mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(6)=1 &&
   //       (inst(15:12)(0)=1 ||
@@ -13826,7 +13826,7 @@ safety(Instruction inst) const {
 
 RegisterList VTST_111100100dssnnnndddd1000nqm1mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -13872,14 +13872,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VUZP_111100111d11ss10dddd00010qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VUZP_111100111d11ss10dddd00010qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(22):inst(15:12)  ==
   //          inst(5):inst(3:0) => UNKNOWN
@@ -13914,7 +13914,7 @@ safety(Instruction inst) const {
 
 RegisterList VUZP_111100111d11ss10dddd00010qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -13960,14 +13960,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList VZIP_111100111d11ss10dddd00011qm0mmmm_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel VZIP_111100111d11ss10dddd00011qm0mmmm_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // inst(22):inst(15:12)  ==
   //          inst(5):inst(3:0) => UNKNOWN
@@ -14002,7 +14002,7 @@ safety(Instruction inst) const {
 
 RegisterList VZIP_111100111d11ss10dddd00011qm0mmmm_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -14018,14 +14018,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList WFE_cccc0011001000001111000000000010_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel WFE_cccc0011001000001111000000000010_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -14037,7 +14037,7 @@ safety(Instruction inst) const {
 
 RegisterList WFE_cccc0011001000001111000000000010_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -14053,14 +14053,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList WFI_cccc0011001000001111000000000011_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel WFI_cccc0011001000001111000000000011_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -14072,7 +14072,7 @@ safety(Instruction inst) const {
 
 RegisterList WFI_cccc0011001000001111000000000011_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -14086,14 +14086,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList YIELD_cccc0011001000001111000000000001_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel YIELD_cccc0011001000001111000000000001_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   return MAY_BE_SAFE;
 }
@@ -14101,7 +14101,7 @@ safety(Instruction inst) const {
 
 RegisterList YIELD_cccc0011001000001111000000000001_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }
@@ -14116,14 +14116,14 @@ uses(Instruction inst) const {
 //    uses: {}}
 RegisterList extra_load_store_instructions_unpriviledged_cccc0000xx1xxxxxxxxxxxxx1xx1xxxx_case_0::
 defs(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // defs: '{}'
   return RegisterList();
 }
 
 SafetyLevel extra_load_store_instructions_unpriviledged_cccc0000xx1xxxxxxxxxxxxx1xx1xxxx_case_0::
 safety(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
 
   // true => FORBIDDEN
   if (true)
@@ -14135,7 +14135,7 @@ safety(Instruction inst) const {
 
 RegisterList extra_load_store_instructions_unpriviledged_cccc0000xx1xxxxxxxxxxxxx1xx1xxxx_case_0::
 uses(Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);  // To silence compiler.
+  NACL_UNUSED_PARAMETER(inst);  // To silence compiler.
   // uses: '{}'
   return RegisterList();
 }

--- a/src/trusted/validator_arm/gen/arm32_decode_named.cc
+++ b/src/trusted/validator_arm/gen/arm32_decode_named.cc
@@ -215,7 +215,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_advanced_simd_data_proce
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_advanced_simd_element_or_structure_load_store_instructions(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00200000)  ==
           0x00000000 /* L(21)=0 */ &&
       (inst.Bits() & 0x00800000)  ==
@@ -519,7 +519,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_advanced_simd_element_or
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_branch_branch_with_link_and_block_data_transfer(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x03D00000)  ==
           0x00000000 /* op(25:20)=0000x0 */) {
     return STMDA_STMED_cccc100000w0nnnnrrrrrrrrrrrrrrrr_case_0_STMDA_STMED_instance_;
@@ -862,7 +862,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_data_processing_and_misc
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_data_processing_immediate(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x01F00000)  ==
           0x01100000 /* op(24:20)=10001 */ &&
       (inst.Bits() & 0x0000F000)  ==
@@ -984,7 +984,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_data_processing_immediat
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_data_processing_register(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x01F00000)  ==
           0x01100000 /* op1(24:20)=10001 */ &&
       (inst.Bits() & 0x0000F000)  ==
@@ -1143,7 +1143,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_data_processing_register
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_data_processing_register_shifted_register(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x01F00000)  ==
           0x01100000 /* op1(24:20)=10001 */ &&
       (inst.Bits() & 0x0000F000)  ==
@@ -1435,7 +1435,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_extension_register_load_
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_extra_load_store_instructions(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00000060)  ==
           0x00000020 /* op2(6:5)=01 */ &&
       (inst.Bits() & 0x00500000)  ==
@@ -1665,7 +1665,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_floating_point_data_proc
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_halfword_multiply_and_multiply_accumulate(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00600000)  ==
           0x00000000 /* op1(22:21)=00 */) {
     return SMLABB_SMLABT_SMLATB_SMLATT_cccc00010000ddddaaaammmm1xx0nnnn_case_0_SMLABB_SMLABT_SMLATB_SMLATT_instance_;
@@ -1710,7 +1710,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_halfword_multiply_and_mu
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_load_store_word_and_unsigned_byte(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x02000000)  ==
           0x00000000 /* A(25)=0 */ &&
       (inst.Bits() & 0x01700000)  ==
@@ -2375,7 +2375,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_miscellaneous_instructio
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_msr_immediate_and_hints(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00400000)  ==
           0x00000000 /* op(22)=0 */ &&
       (inst.Bits() & 0x000F0000)  ==
@@ -2500,7 +2500,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_msr_immediate_and_hints(
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_multiply_and_multiply_accumulate(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00F00000)  ==
           0x00400000 /* op(23:20)=0100 */) {
     return UMAAL_A1_cccc00000100hhhhllllmmmm1001nnnn_case_0_UMAAL_A1_instance_;
@@ -2564,7 +2564,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_multiply_and_multiply_ac
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_other_floating_point_data_processing_instructions(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x000F0000)  ==
           0x00000000 /* opc2(19:16)=0000 */ &&
       (inst.Bits() & 0x000000C0)  ==
@@ -2664,7 +2664,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_other_floating_point_dat
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_packing_unpacking_saturation_and_reversal(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00700000)  ==
           0x00000000 /* op1(22:20)=000 */ &&
       (inst.Bits() & 0x000000E0)  ==
@@ -2896,7 +2896,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_packing_unpacking_satura
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_parallel_addition_and_subtraction_signed(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00300000)  ==
           0x00100000 /* op1(21:20)=01 */ &&
       (inst.Bits() & 0x000000E0)  ==
@@ -3074,7 +3074,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_parallel_addition_and_su
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_parallel_addition_and_subtraction_unsigned(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00300000)  ==
           0x00100000 /* op1(21:20)=01 */ &&
       (inst.Bits() & 0x000000E0)  ==
@@ -3252,7 +3252,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_parallel_addition_and_su
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_saturating_addition_and_subtraction(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00600000)  ==
           0x00000000 /* op(22:21)=00 */ &&
       (inst.Bits() & 0x00000F00)  ==
@@ -3292,7 +3292,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_saturating_addition_and_
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_signed_multiply_signed_and_unsigned_divide(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00700000)  ==
           0x00000000 /* op1(22:20)=000 */ &&
       (inst.Bits() & 0x000000C0)  ==
@@ -3401,7 +3401,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_signed_multiply_signed_a
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_simd_dp_1imm(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00000020)  ==
           0x00000000 /* op(5)=0 */ &&
       (inst.Bits() & 0x00000D00)  ==
@@ -3497,7 +3497,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_simd_dp_1imm(
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_simd_dp_2misc(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00030000)  ==
           0x00000000 /* A(17:16)=00 */ &&
       (inst.Bits() & 0x00000780)  ==
@@ -3772,7 +3772,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_simd_dp_2misc(
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_simd_dp_2scalar(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00000F00)  ==
           0x00000000 /* A(11:8)=0000 */) {
     return VMLA_by_scalar_A1_1111001q1dssnnnndddd0p0fn1m0mmmm_case_1_VMLA_by_scalar_A1_instance_;
@@ -3864,7 +3864,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_simd_dp_2scalar(
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_simd_dp_2shift(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00000F00)  ==
           0x00000000 /* A(11:8)=0000 */) {
     return VSHR_1111001u1diiiiiidddd0000lqm1mmmm_case_0_VSHR_instance_;
@@ -4017,7 +4017,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_simd_dp_2shift(
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_simd_dp_3diff(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00000F00)  ==
           0x00000400 /* A(11:8)=0100 */ &&
       (inst.Bits() & 0x01000000)  ==
@@ -4110,7 +4110,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_simd_dp_3diff(
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_simd_dp_3same(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00000F00)  ==
           0x00000000 /* A(11:8)=0000 */ &&
       (inst.Bits() & 0x00000010)  ==
@@ -4662,7 +4662,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_simd_dp_3same(
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_synchronization_primitives(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00F00000)  ==
           0x00800000 /* op(23:20)=1000 */ &&
       (inst.Bits() & 0x00000F00)  ==
@@ -4741,7 +4741,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_synchronization_primitiv
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_transfer_between_arm_core_and_extension_register_8_16_and_32_bit(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00100000)  ==
           0x00000000 /* L(20)=0 */ &&
       (inst.Bits() & 0x00000100)  ==
@@ -4834,7 +4834,7 @@ const NamedClassDecoder& NamedArm32DecoderState::decode_transfer_between_arm_cor
  */
 const NamedClassDecoder& NamedArm32DecoderState::decode_transfer_between_arm_core_and_extension_registers_64_bit(
      const nacl_arm_dec::Instruction inst) const {
-  UNREFERENCED_PARAMETER(inst);
+  NACL_UNUSED_PARAMETER(inst);
   if ((inst.Bits() & 0x00000100)  ==
           0x00000000 /* C(8)=0 */ &&
       (inst.Bits() & 0x000000D0)  ==

--- a/src/trusted/validator_arm/inst_classes.cc
+++ b/src/trusted/validator_arm/inst_classes.cc
@@ -13,68 +13,68 @@ namespace nacl_arm_dec {
 
 // ClassDecoder
 RegisterList ClassDecoder::defs(Instruction i) const {
-  UNREFERENCED_PARAMETER(i);
+  NACL_UNUSED_PARAMETER(i);
   return RegisterList::Everything();
 }
 
 RegisterList ClassDecoder::uses(Instruction i) const {
-  UNREFERENCED_PARAMETER(i);
+  NACL_UNUSED_PARAMETER(i);
   return RegisterList();
 }
 
 bool ClassDecoder::base_address_register_writeback_small_immediate(
     Instruction i) const {
-  UNREFERENCED_PARAMETER(i);
+  NACL_UNUSED_PARAMETER(i);
   return false;
 }
 
 Register ClassDecoder::base_address_register(Instruction i) const {
-  UNREFERENCED_PARAMETER(i);
+  NACL_UNUSED_PARAMETER(i);
   return Register::None();
 }
 
 bool ClassDecoder::is_literal_load(Instruction i) const {
-  UNREFERENCED_PARAMETER(i);
+  NACL_UNUSED_PARAMETER(i);
   return false;
 }
 
 Register ClassDecoder::branch_target_register(Instruction i) const {
-  UNREFERENCED_PARAMETER(i);
+  NACL_UNUSED_PARAMETER(i);
   return Register::None();
 }
 
 bool ClassDecoder::is_relative_branch(Instruction i) const {
-  UNREFERENCED_PARAMETER(i);
+  NACL_UNUSED_PARAMETER(i);
   return false;
 }
 
 int32_t ClassDecoder::branch_target_offset(Instruction i) const {
-  UNREFERENCED_PARAMETER(i);
+  NACL_UNUSED_PARAMETER(i);
   return 0;
 }
 
 bool ClassDecoder::is_literal_pool_head(Instruction i) const {
-  UNREFERENCED_PARAMETER(i);
+  NACL_UNUSED_PARAMETER(i);
   return false;
 }
 
 bool ClassDecoder::clears_bits(Instruction i, uint32_t mask) const {
-  UNREFERENCED_PARAMETER(i);
-  UNREFERENCED_PARAMETER(mask);
+  NACL_UNUSED_PARAMETER(i);
+  NACL_UNUSED_PARAMETER(mask);
   return false;
 }
 
 bool ClassDecoder::sets_Z_if_bits_clear(Instruction i,
                                         Register r,
                                         uint32_t mask) const {
-  UNREFERENCED_PARAMETER(i);
-  UNREFERENCED_PARAMETER(r);
-  UNREFERENCED_PARAMETER(mask);
+  NACL_UNUSED_PARAMETER(i);
+  NACL_UNUSED_PARAMETER(r);
+  NACL_UNUSED_PARAMETER(mask);
   return false;
 }
 
 bool ClassDecoder::is_load_thread_address_pointer(Instruction i) const {
-  UNREFERENCED_PARAMETER(i);
+  NACL_UNUSED_PARAMETER(i);
   return false;
 }
 
@@ -90,7 +90,7 @@ ViolationSet ClassDecoder::get_violations(
     nacl_arm_val::AddressSet* branches,
     nacl_arm_val::AddressSet* critical,
     uint32_t* next_inst_addr) const {
-  UNREFERENCED_PARAMETER(next_inst_addr);
+  NACL_UNUSED_PARAMETER(next_inst_addr);
   ViolationSet violations = kNoViolations;
 
   // Start by checking safety.

--- a/src/trusted/validator_arm/inst_classes_inline.h
+++ b/src/trusted/validator_arm/inst_classes_inline.h
@@ -378,7 +378,7 @@ static inline void generate_call_position_diagnostics(
       const nacl_arm_val::DecodedInstruction& inst,
       const nacl_arm_val::SfiValidator& sfi,
       nacl_arm_val::ProblemSink* out) {
-  UNREFERENCED_PARAMETER(sfi);
+  NACL_UNUSED_PARAMETER(sfi);
   if (ContainsViolation(violations, CALL_POSITION_VIOLATION)) {
     out->ReportProblemDiagnostic(
         CALL_POSITION_VIOLATION,
@@ -403,7 +403,7 @@ static inline void generate_read_only_diagnostics(
     const nacl_arm_val::DecodedInstruction& inst,
     const nacl_arm_val::SfiValidator& sfi,
     nacl_arm_val::ProblemSink* out) {
-  UNREFERENCED_PARAMETER(sfi);
+  NACL_UNUSED_PARAMETER(sfi);
   if (ContainsViolation(violations, READ_ONLY_VIOLATION)) {
     RegisterList& read_only = inst.defs().Intersect(sfi.read_only_registers());
     for (Register::Number r = 0; r < Register::kNumberGPRs; ++r) {
@@ -434,7 +434,7 @@ static inline void generate_read_thread_local_pointer_diagnostics(
     const nacl_arm_val::DecodedInstruction& inst,
     const nacl_arm_val::SfiValidator& sfi,
     nacl_arm_val::ProblemSink* out) {
-  UNREFERENCED_PARAMETER(sfi);
+  NACL_UNUSED_PARAMETER(sfi);
   if (ContainsViolation(violations, READ_THREAD_LOCAL_POINTER_VIOLATION)) {
     out->ReportProblemDiagnostic(
         READ_THREAD_LOCAL_POINTER_VIOLATION,
@@ -477,7 +477,7 @@ static inline void generate_pc_writes_diagnostics(
     const nacl_arm_val::DecodedInstruction& inst,
     const nacl_arm_val::SfiValidator& sfi,
     nacl_arm_val::ProblemSink* out) {
-  UNREFERENCED_PARAMETER(sfi);
+  NACL_UNUSED_PARAMETER(sfi);
   if (ContainsViolation(violations, PC_WRITES_VIOLATION)) {
     out->ReportProblemDiagnostic(
         PC_WRITES_VIOLATION,

--- a/src/trusted/validator_arm/ncval.cc
+++ b/src/trusted/validator_arm/ncval.cc
@@ -53,8 +53,8 @@ void NcvalProblemReporter::
 ReportProblemMessage(nacl_arm_dec::Violation violation,
                      uint32_t vaddr,
                      const char* message) {
-  UNREFERENCED_PARAMETER(vaddr);
-  UNREFERENCED_PARAMETER(violation);
+  NACL_UNUSED_PARAMETER(vaddr);
+  NACL_UNUSED_PARAMETER(violation);
   printf("%8" NACL_PRIx32 ": %s\n", vaddr, message);
 }
 

--- a/src/trusted/validator_arm/ncvalidate.cc
+++ b/src/trusted/validator_arm/ncvalidate.cc
@@ -149,7 +149,7 @@ static NaClValidationStatus ApplyValidatorArm(
     const struct NaClValidationMetadata *metadata,
     struct NaClValidationCache *cache) {
   // The ARM validator never modifies the text, so this flag can be ignored.
-  UNREFERENCED_PARAMETER(readonly_text);
+  NACL_UNUSED_PARAMETER(readonly_text);
   CHECK((flags & NACL_VALIDATION_FLAGS_MASK_ARM) == 0);
   CheckAddressAlignAndOverflow((uint8_t *) guest_addr, size);
   CheckAddressOverflow(data, size);

--- a/src/trusted/validator_mips/inst_classes.h
+++ b/src/trusted/validator_mips/inst_classes.h
@@ -78,9 +78,9 @@ class ClassDecoder {
   virtual bool IsMask(const Instruction instr,
                       const nacl_mips_dec::Register dest,
                       const nacl_mips_dec::Register mask) const {
-    UNREFERENCED_PARAMETER(instr);
-    UNREFERENCED_PARAMETER(dest);
-    UNREFERENCED_PARAMETER(mask);
+    NACL_UNUSED_PARAMETER(instr);
+    NACL_UNUSED_PARAMETER(dest);
+    NACL_UNUSED_PARAMETER(mask);
     return false;
   }
 
@@ -88,7 +88,7 @@ class ClassDecoder {
    * The gpr register altered by the instruction.
    */
   virtual Register DestGprReg(const Instruction instr) const {
-    UNREFERENCED_PARAMETER(instr);
+    NACL_UNUSED_PARAMETER(instr);
     return Register::None();
   }
 
@@ -96,7 +96,7 @@ class ClassDecoder {
    * May be used for instr's with immediate operand; like addiu or jal.
    */
   virtual uint32_t GetImm(const Instruction instr) const {
-    UNREFERENCED_PARAMETER(instr);
+    NACL_UNUSED_PARAMETER(instr);
     return -1;
   }
 
@@ -146,8 +146,8 @@ class ClassDecoder {
    * For direct jumps, returning the destination address.
    */
   virtual uint32_t DestAddr(const Instruction instr, uint32_t addr) const {
-    UNREFERENCED_PARAMETER(instr);
-    UNREFERENCED_PARAMETER(addr);
+    NACL_UNUSED_PARAMETER(instr);
+    NACL_UNUSED_PARAMETER(addr);
     return 0;
   }
 
@@ -156,7 +156,7 @@ class ClassDecoder {
    * address to jump to.
    */
   virtual Register TargetReg(const Instruction instr) const {
-    UNREFERENCED_PARAMETER(instr);
+    NACL_UNUSED_PARAMETER(instr);
     return Register::None();
   }
 
@@ -164,7 +164,7 @@ class ClassDecoder {
    * Base address register, for load and store instructions.
    */
   virtual Register BaseAddressRegister(const Instruction instr) const {
-    UNREFERENCED_PARAMETER(instr);
+    NACL_UNUSED_PARAMETER(instr);
     return Register::None();
   }
 
@@ -181,7 +181,7 @@ class NaClHalt : public ClassDecoder {
  public:
   virtual ~NaClHalt() {}
   virtual SafetyLevel safety(const Instruction instr) const {
-    UNREFERENCED_PARAMETER(instr);
+    NACL_UNUSED_PARAMETER(instr);
     return MAY_BE_SAFE;
   }
 };
@@ -194,7 +194,7 @@ class Forbidden : public ClassDecoder {
  public:
   virtual ~Forbidden() {}
   virtual SafetyLevel safety(const Instruction instr) const {
-    UNREFERENCED_PARAMETER(instr);
+    NACL_UNUSED_PARAMETER(instr);
     return FORBIDDEN;
   }
 };
@@ -210,7 +210,7 @@ class Arithm2 : public ClassDecoder {
     return instr.Reg(20, 16);
   }
   virtual SafetyLevel safety(const Instruction instr) const {
-    UNREFERENCED_PARAMETER(instr);
+    NACL_UNUSED_PARAMETER(instr);
     return MAY_BE_SAFE;
   }
 };
@@ -226,7 +226,7 @@ class Arithm3 : public ClassDecoder {
     return instr.Reg(15, 11);
   }
   virtual SafetyLevel safety(const Instruction instr) const {
-    UNREFERENCED_PARAMETER(instr);
+    NACL_UNUSED_PARAMETER(instr);
     return MAY_BE_SAFE;
   }
   virtual bool IsMask(const Instruction instr,
@@ -246,7 +246,7 @@ class DirectJump : public ClassDecoder {
  public:
   virtual ~DirectJump() {}
   virtual SafetyLevel safety(const Instruction instr) const {
-    UNREFERENCED_PARAMETER(instr);
+    NACL_UNUSED_PARAMETER(instr);
     return MAY_BE_SAFE;
   }
   virtual bool IsDirectJump() const {
@@ -289,7 +289,7 @@ class AbstractLoadStore : public ClassDecoder {
   }
   virtual ~AbstractLoadStore() {}
   virtual SafetyLevel safety(const Instruction instr) const {
-    UNREFERENCED_PARAMETER(instr);
+    NACL_UNUSED_PARAMETER(instr);
     return MAY_BE_SAFE;
   }
   virtual Register BaseAddressRegister(const Instruction instr) const {
@@ -382,7 +382,7 @@ class JmpReg : public ClassDecoder {
  public:
   virtual ~JmpReg() {}
   virtual SafetyLevel safety(const Instruction instr) const {
-    UNREFERENCED_PARAMETER(instr);
+    NACL_UNUSED_PARAMETER(instr);
     return MAY_BE_SAFE;
   }
   virtual bool IsJmpReg() const {
@@ -417,7 +417,7 @@ class ExtIns : public ClassDecoder {
     return instr.Reg(20, 16);
   }
   virtual SafetyLevel safety(const Instruction instr) const {
-    UNREFERENCED_PARAMETER(instr);
+    NACL_UNUSED_PARAMETER(instr);
     return MAY_BE_SAFE;
   }
 };
@@ -428,7 +428,7 @@ class Safe : public ClassDecoder {
  public:
   virtual ~Safe() {}
   virtual SafetyLevel safety(const Instruction instr) const {
-    UNREFERENCED_PARAMETER(instr);
+    NACL_UNUSED_PARAMETER(instr);
     return MAY_BE_SAFE;
   }
 };
@@ -437,7 +437,7 @@ class Other : public ClassDecoder {
  public:
   virtual ~Other() {}
   virtual SafetyLevel safety(const Instruction instr) const {
-    UNREFERENCED_PARAMETER(instr);
+    NACL_UNUSED_PARAMETER(instr);
     return FORBIDDEN;
   }
 };
@@ -449,7 +449,7 @@ class Unrecognized : public ClassDecoder {
  public:
   virtual ~Unrecognized() {}
   virtual SafetyLevel safety(const Instruction instr) const {
-    UNREFERENCED_PARAMETER(instr);
+    NACL_UNUSED_PARAMETER(instr);
     return FORBIDDEN;
   }
 };

--- a/src/trusted/validator_mips/ncvalidate.cc
+++ b/src/trusted/validator_mips/ncvalidate.cc
@@ -36,10 +36,10 @@ class EarlyExitProblemSink : public nacl_mips_val::ProblemSink {
                               nacl_mips_dec::SafetyLevel safety,
                               const nacl::string &problem_code,
                               uint32_t ref_vaddr) {
-    UNREFERENCED_PARAMETER(vaddr);
-    UNREFERENCED_PARAMETER(safety);
-    UNREFERENCED_PARAMETER(problem_code);
-    UNREFERENCED_PARAMETER(ref_vaddr);
+    NACL_UNUSED_PARAMETER(vaddr);
+    NACL_UNUSED_PARAMETER(safety);
+    NACL_UNUSED_PARAMETER(problem_code);
+    NACL_UNUSED_PARAMETER(ref_vaddr);
 
     problems_ = true;
   }
@@ -62,9 +62,9 @@ class StuboutProblemSink : public nacl_mips_val::ProblemSink {
                               nacl_mips_dec::SafetyLevel safety,
                               const nacl::string &problem_code,
                               uint32_t ref_vaddr) {
-    UNREFERENCED_PARAMETER(safety);
-    UNREFERENCED_PARAMETER(problem_code);
-    UNREFERENCED_PARAMETER(ref_vaddr);
+    NACL_UNUSED_PARAMETER(safety);
+    NACL_UNUSED_PARAMETER(problem_code);
+    NACL_UNUSED_PARAMETER(ref_vaddr);
     stub_out_instr(vaddr);
 
     problems_ = true;
@@ -179,11 +179,11 @@ static NaClValidationStatus ValidatorCodeReplacementNotImplemented(
      uint8_t *data_new,
      size_t size,
      const NaClCPUFeatures *cpu_features) {
-  UNREFERENCED_PARAMETER(guest_addr);
-  UNREFERENCED_PARAMETER(data_old);
-  UNREFERENCED_PARAMETER(data_new);
-  UNREFERENCED_PARAMETER(size);
-  UNREFERENCED_PARAMETER(cpu_features);
+  NACL_UNUSED_PARAMETER(guest_addr);
+  NACL_UNUSED_PARAMETER(data_old);
+  NACL_UNUSED_PARAMETER(data_new);
+  NACL_UNUSED_PARAMETER(size);
+  NACL_UNUSED_PARAMETER(cpu_features);
   return NaClValidationFailedNotImplemented;
 }
 
@@ -194,12 +194,12 @@ static NaClValidationStatus ValidatorCopyNotImplemented(
      size_t size,
      const NaClCPUFeatures *cpu_features,
      NaClCopyInstructionFunc copy_func) {
-  UNREFERENCED_PARAMETER(guest_addr);
-  UNREFERENCED_PARAMETER(data_old);
-  UNREFERENCED_PARAMETER(data_new);
-  UNREFERENCED_PARAMETER(size);
-  UNREFERENCED_PARAMETER(cpu_features);
-  UNREFERENCED_PARAMETER(copy_func);
+  NACL_UNUSED_PARAMETER(guest_addr);
+  NACL_UNUSED_PARAMETER(data_old);
+  NACL_UNUSED_PARAMETER(data_new);
+  NACL_UNUSED_PARAMETER(size);
+  NACL_UNUSED_PARAMETER(cpu_features);
+  NACL_UNUSED_PARAMETER(copy_func);
   return NaClValidationFailedNotImplemented;
 }
 
@@ -209,11 +209,11 @@ static NaClValidationStatus IsOnInstBoundaryMips(
     const uint8_t *data,
     size_t size,
     const NaClCPUFeatures *f) {
-  UNREFERENCED_PARAMETER(guest_addr);
-  UNREFERENCED_PARAMETER(addr);
-  UNREFERENCED_PARAMETER(data);
-  UNREFERENCED_PARAMETER(size);
-  UNREFERENCED_PARAMETER(f);
+  NACL_UNUSED_PARAMETER(guest_addr);
+  NACL_UNUSED_PARAMETER(addr);
+  NACL_UNUSED_PARAMETER(data);
+  NACL_UNUSED_PARAMETER(size);
+  NACL_UNUSED_PARAMETER(f);
   return NaClValidationFailedNotImplemented;
 }
 
@@ -239,9 +239,9 @@ const struct NaClValidatorInterface *NaClValidatorCreateMips() {
  * moved to be part of sel_ldr, not the validator.
  */
 int NaClCopyInstruction(uint8_t *dst, uint8_t *src, uint8_t sz) {
-  UNREFERENCED_PARAMETER(dst);
-  UNREFERENCED_PARAMETER(src);
-  UNREFERENCED_PARAMETER(sz);
+  NACL_UNUSED_PARAMETER(dst);
+  NACL_UNUSED_PARAMETER(src);
+  NACL_UNUSED_PARAMETER(sz);
 
   return 0;
 }

--- a/src/trusted/validator_mips/validator.cc
+++ b/src/trusted/validator_mips/validator.cc
@@ -55,7 +55,7 @@ enum PatternMatch {
 static PatternMatch CheckSafety(const SfiValidator &sfi,
                                 const DecodedInstruction &inst,
                                 ProblemSink *out) {
-  UNREFERENCED_PARAMETER(sfi);
+  NACL_UNUSED_PARAMETER(sfi);
   if (nacl_mips_dec::MAY_BE_SAFE != inst.safety()) {
     out->ReportProblem(inst.addr(), inst.safety(), kProblemUnsafe);
     return PATTERN_UNSAFE;
@@ -141,7 +141,7 @@ static PatternMatch CheckJmpReg(const SfiValidator &sfi,
                                 const DecodedInstruction &first,
                                 const DecodedInstruction &second,
                                 ProblemSink *out) {
-  UNREFERENCED_PARAMETER(sfi);
+  NACL_UNUSED_PARAMETER(sfi);
   if (second.IsJmpReg()) {
     if (first.IsMask(second.TargetReg(), Register::JumpMask())) {
       return PATTERN_SAFE;
@@ -161,7 +161,7 @@ static PatternMatch CheckDataRegisterUpdate(const SfiValidator &sfi,
                                             const DecodedInstruction &first,
                                             const DecodedInstruction &second,
                                             ProblemSink *out) {
-  UNREFERENCED_PARAMETER(sfi);
+  NACL_UNUSED_PARAMETER(sfi);
   if (first.DestGprReg().Equals(Register::Sp())
       && !first.IsMask(first.DestGprReg(), Register::LoadStoreMask())) {
     if (second.IsMask(first.DestGprReg(), Register::LoadStoreMask())) {
@@ -180,7 +180,7 @@ static PatternMatch CheckDataRegisterDslot(const SfiValidator &sfi,
                                            const DecodedInstruction &first,
                                            const DecodedInstruction &second,
                                            ProblemSink *out) {
-  UNREFERENCED_PARAMETER(sfi);
+  NACL_UNUSED_PARAMETER(sfi);
   if (second.DestGprReg().Equals(Register::Sp())
       && !second.IsMask(second.DestGprReg(), Register::LoadStoreMask())) {
     if (first.HasDelaySlot()) {
@@ -223,7 +223,7 @@ static PatternMatch CheckLoadStore(const SfiValidator &sfi,
 static PatternMatch CheckLoadThreadPointer(const SfiValidator &sfi,
                                            const DecodedInstruction &instr,
                                            ProblemSink *out) {
-  UNREFERENCED_PARAMETER(sfi);
+  NACL_UNUSED_PARAMETER(sfi);
   if (!instr.IsLoadStore())
     return NO_MATCH;
 
@@ -249,7 +249,7 @@ static PatternMatch CheckBranchInDelaySlot(const SfiValidator &sfi,
                                    const DecodedInstruction &first,
                                    const DecodedInstruction &second,
                                    ProblemSink *out) {
-  UNREFERENCED_PARAMETER(sfi);
+  NACL_UNUSED_PARAMETER(sfi);
   if (first.HasDelaySlot() && second.HasDelaySlot()) {
     out->ReportProblem(second.addr(), second.safety(),
                        kProblemBranchInDelaySlot);

--- a/src/trusted/validator_mips/validator.h
+++ b/src/trusted/validator_mips/validator.h
@@ -365,10 +365,10 @@ class ProblemSink {
    */
   virtual void ReportProblem(uint32_t vaddr, nacl_mips_dec::SafetyLevel safety,
       const nacl::string &problem_code, uint32_t ref_vaddr = 0) {
-    UNREFERENCED_PARAMETER(vaddr);
-    UNREFERENCED_PARAMETER(safety);
-    UNREFERENCED_PARAMETER(problem_code);
-    UNREFERENCED_PARAMETER(ref_vaddr);
+    NACL_UNUSED_PARAMETER(vaddr);
+    NACL_UNUSED_PARAMETER(safety);
+    NACL_UNUSED_PARAMETER(problem_code);
+    NACL_UNUSED_PARAMETER(ref_vaddr);
   }
 
   /*

--- a/src/trusted/validator_ragel/bitmap.h
+++ b/src/trusted/validator_ragel/bitmap.h
@@ -16,9 +16,9 @@
 #include "native_client/src/include/portability.h"
 
 #if defined(_MSC_VER)
-# define FORCEINLINE __forceinline
+# define NACL_FORCEINLINE __forceinline
 #else
-# define FORCEINLINE __inline __attribute__ ((always_inline))
+# define NACL_FORCEINLINE __inline __attribute__ ((always_inline))
 #endif
 
 typedef NACL_CONCAT(NACL_CONCAT(uint, NACL_HOST_WORDSIZE), _t) bitmap_word;
@@ -29,30 +29,30 @@ static INLINE bitmap_word *BitmapAllocate(size_t indexes) {
   return calloc(word_count, sizeof(bitmap_word));
 }
 
-static FORCEINLINE int BitmapIsBitSet(bitmap_word *bitmap, size_t index) {
+static NACL_FORCEINLINE int BitmapIsBitSet(bitmap_word *bitmap, size_t index) {
   return (bitmap[index / NACL_HOST_WORDSIZE] &
                        (((bitmap_word)1) << (index % NACL_HOST_WORDSIZE))) != 0;
 }
 
-static FORCEINLINE void BitmapSetBit(bitmap_word *bitmap, size_t index) {
+static NACL_FORCEINLINE void BitmapSetBit(bitmap_word *bitmap, size_t index) {
   bitmap[index / NACL_HOST_WORDSIZE] |=
                                ((bitmap_word)1) << (index % NACL_HOST_WORDSIZE);
 }
 
-static FORCEINLINE void BitmapClearBit(bitmap_word *bitmap, size_t index) {
+static NACL_FORCEINLINE void BitmapClearBit(bitmap_word *bitmap, size_t index) {
   bitmap[index / NACL_HOST_WORDSIZE] &=
                             ~(((bitmap_word)1) << (index % NACL_HOST_WORDSIZE));
 }
 
 /* All the bits must be in a single 32-bit bundle.  */
-static FORCEINLINE int BitmapIsAnyBitSet(bitmap_word *bitmap,
+static NACL_FORCEINLINE int BitmapIsAnyBitSet(bitmap_word *bitmap,
                                          size_t index, size_t bits) {
   return (bitmap[index / NACL_HOST_WORDSIZE] &
        (((((bitmap_word)1) << bits) - 1) << (index % NACL_HOST_WORDSIZE))) != 0;
 }
 
 /* All the bits must be in a single 32-bit bundle. */
-static FORCEINLINE void BitmapSetBits(bitmap_word *bitmap,
+static NACL_FORCEINLINE void BitmapSetBits(bitmap_word *bitmap,
                                       size_t index,
                                       size_t bits) {
   bitmap[index / NACL_HOST_WORDSIZE] |=
@@ -60,7 +60,7 @@ static FORCEINLINE void BitmapSetBits(bitmap_word *bitmap,
 }
 
 /* All the bits must be in a single 32-bit bundle. */
-static FORCEINLINE void BitmapClearBits(bitmap_word *bitmap,
+static NACL_FORCEINLINE void BitmapClearBits(bitmap_word *bitmap,
                                         size_t index, size_t bits) {
   bitmap[index / NACL_HOST_WORDSIZE] &=
             ~(((((bitmap_word)1) << bits) - 1) << (index % NACL_HOST_WORDSIZE));

--- a/src/trusted/validator_ragel/decoder_internal.h
+++ b/src/trusted/validator_ragel/decoder_internal.h
@@ -66,7 +66,7 @@ enum ImmediateMode {
   IMM64
 };
 
-static FORCEINLINE uint64_t DecodeDisplacementValue(
+static NACL_FORCEINLINE uint64_t DecodeDisplacementValue(
     enum DisplacementMode disp_mode, const uint8_t *disp_ptr) {
   switch(disp_mode) {
     case DISPNONE: return 0;
@@ -80,7 +80,7 @@ static FORCEINLINE uint64_t DecodeDisplacementValue(
 }
 
 
-static FORCEINLINE uint64_t DecodeImmediateValue(enum ImmediateMode imm_mode,
+static NACL_FORCEINLINE uint64_t DecodeImmediateValue(enum ImmediateMode imm_mode,
                                                  const uint8_t *imm_ptr) {
   switch(imm_mode) {
     case IMMNONE: return 0;

--- a/src/trusted/validator_ragel/decoding.h
+++ b/src/trusted/validator_ragel/decoding.h
@@ -20,9 +20,9 @@
 #include "native_client/src/trusted/validator_ragel/decoder.h"
 
 #if defined(_MSC_VER)
-# define FORCEINLINE __forceinline
+# define NACL_FORCEINLINE __forceinline
 #else
-# define FORCEINLINE __inline __attribute__ ((always_inline))
+# define NACL_FORCEINLINE __inline __attribute__ ((always_inline))
 #endif
 
 
@@ -32,7 +32,7 @@
  * bits 0-2: register number
  * bits 3-7: actual opcode
  */
-static FORCEINLINE uint8_t RegFromOpcode(uint8_t modrm) {
+static NACL_FORCEINLINE uint8_t RegFromOpcode(uint8_t modrm) {
   return modrm & 0x07;
 }
 
@@ -43,15 +43,15 @@ static FORCEINLINE uint8_t RegFromOpcode(uint8_t modrm) {
  * bits 3-5: reg
  * bits 6-7: mod
  */
-static FORCEINLINE uint8_t ModFromModRM(uint8_t modrm) {
+static NACL_FORCEINLINE uint8_t ModFromModRM(uint8_t modrm) {
   return modrm >> 6;
 }
 
-static FORCEINLINE uint8_t RegFromModRM(uint8_t modrm) {
+static NACL_FORCEINLINE uint8_t RegFromModRM(uint8_t modrm) {
   return (modrm >> 3) & 0x07;
 }
 
-static FORCEINLINE uint8_t RMFromModRM(uint8_t modrm) {
+static NACL_FORCEINLINE uint8_t RMFromModRM(uint8_t modrm) {
   return modrm & 0x07;
 }
 
@@ -62,15 +62,15 @@ static FORCEINLINE uint8_t RMFromModRM(uint8_t modrm) {
  * bits 3-5: index
  * bits 6-7: scale
  */
-static FORCEINLINE uint8_t ScaleFromSIB(uint8_t sib) {
+static NACL_FORCEINLINE uint8_t ScaleFromSIB(uint8_t sib) {
   return sib >> 6;
 }
 
-static FORCEINLINE uint8_t IndexFromSIB(uint8_t sib) {
+static NACL_FORCEINLINE uint8_t IndexFromSIB(uint8_t sib) {
   return (sib >> 3) & 0x07;
 }
 
-static FORCEINLINE uint8_t BaseFromSIB(uint8_t sib) {
+static NACL_FORCEINLINE uint8_t BaseFromSIB(uint8_t sib) {
   return sib & 0x07;
 }
 
@@ -92,17 +92,17 @@ enum {
 };
 
 /* How much to add to "base register" number: 0 or 8  */
-static FORCEINLINE uint8_t BaseExtentionFromREX(uint8_t rex) {
+static NACL_FORCEINLINE uint8_t BaseExtentionFromREX(uint8_t rex) {
   return (rex & REX_B) << 3;
 }
 
 /* How much to add to "index register" number: 0 or 8  */
-static FORCEINLINE uint8_t IndexExtentionFromREX(uint8_t rex) {
+static NACL_FORCEINLINE uint8_t IndexExtentionFromREX(uint8_t rex) {
   return (rex & REX_X) << 2;
 }
 
 /* How much to add to "register operand" number: 0 or 8  */
-static FORCEINLINE uint8_t RegisterExtentionFromREX(uint8_t rex) {
+static NACL_FORCEINLINE uint8_t RegisterExtentionFromREX(uint8_t rex) {
   return (rex & REX_R) << 1;
 }
 
@@ -129,17 +129,17 @@ enum {
 };
 
 /* How much to add to "base register" number: 0 or 8  */
-static FORCEINLINE uint8_t BaseExtentionFromVEX(uint8_t vex2) {
+static NACL_FORCEINLINE uint8_t BaseExtentionFromVEX(uint8_t vex2) {
   return ((~vex2) & VEX_B) >> 2;
 }
 
 /* How much to add to "index register" number: 0 or 8  */
-static FORCEINLINE uint8_t IndexExtentionFromVEX(uint8_t vex2) {
+static NACL_FORCEINLINE uint8_t IndexExtentionFromVEX(uint8_t vex2) {
   return ((~vex2) & VEX_X) >> 3;
 }
 
 /* How much to add to "register operand" number: 0 or 8  */
-static FORCEINLINE uint8_t RegisterExtentionFromVEX(uint8_t vex2) {
+static NACL_FORCEINLINE uint8_t RegisterExtentionFromVEX(uint8_t vex2) {
   return ((~vex2) & VEX_R) >> 4;
 }
 
@@ -163,11 +163,11 @@ enum {
 };
 
 
-static FORCEINLINE uint8_t GetOperandFromVexIA32(uint8_t vex3) {
+static NACL_FORCEINLINE uint8_t GetOperandFromVexIA32(uint8_t vex3) {
   return ((~vex3) & VEX_VVVV) >> 3;
 }
 
-static FORCEINLINE uint8_t GetOperandFromVexAMD64(uint8_t vex3) {
+static NACL_FORCEINLINE uint8_t GetOperandFromVexAMD64(uint8_t vex3) {
   return ((~vex3) & VEX_VVVV) >> 3;
 }
 
@@ -178,7 +178,7 @@ static FORCEINLINE uint8_t GetOperandFromVexAMD64(uint8_t vex3) {
  * bits 2-3: 0
  * bits 4-7: register number
  */
-static FORCEINLINE uint8_t RegisterFromIS4(uint8_t is4) {
+static NACL_FORCEINLINE uint8_t RegisterFromIS4(uint8_t is4) {
   return is4 >> 4;
 }
 
@@ -214,30 +214,30 @@ static FORCEINLINE uint8_t RegisterFromIS4(uint8_t is4) {
  * Conversion from intXX_t to uint64_t is always safe (same as before: see
  * see 6.2.1.2 in C90 specification and 6.3.1.3.2 in C99 specification).
  */
-static FORCEINLINE uint64_t SignExtend8Bit(uint64_t value) {
+static NACL_FORCEINLINE uint64_t SignExtend8Bit(uint64_t value) {
   return (int8_t)value;
 }
 
-static FORCEINLINE uint64_t SignExtend16Bit(uint64_t value) {
+static NACL_FORCEINLINE uint64_t SignExtend16Bit(uint64_t value) {
   return (int16_t)value;
 }
 
-static FORCEINLINE uint64_t SignExtend32Bit(uint64_t value) {
+static NACL_FORCEINLINE uint64_t SignExtend32Bit(uint64_t value) {
   return (int32_t)value;
 }
 
-static FORCEINLINE uint64_t AnyFieldValue8bit(const uint8_t *start) {
+static NACL_FORCEINLINE uint64_t AnyFieldValue8bit(const uint8_t *start) {
   return *start;
 }
 
-static FORCEINLINE uint64_t AnyFieldValue16bit(const uint8_t *start) {
+static NACL_FORCEINLINE uint64_t AnyFieldValue16bit(const uint8_t *start) {
   return (start[0] + 256U * start[1]);
 }
 
-static FORCEINLINE uint64_t AnyFieldValue32bit(const uint8_t *start) {
+static NACL_FORCEINLINE uint64_t AnyFieldValue32bit(const uint8_t *start) {
   return (start[0] + 256U * (start[1] + 256U * (start[2] + 256U * (start[3]))));
 }
-static FORCEINLINE uint64_t AnyFieldValue64bit(const uint8_t *start) {
+static NACL_FORCEINLINE uint64_t AnyFieldValue64bit(const uint8_t *start) {
   return (*start + 256ULL * (start[1] + 256ULL * (start[2] + 256ULL *
           (start[3] + 256ULL * (start[4] + 256ULL * (start[5] + 256ULL *
            (start[6] + 256ULL * start[7])))))));

--- a/src/trusted/validator_ragel/dfa_validate_32.c
+++ b/src/trusted/validator_ragel/dfa_validate_32.c
@@ -47,7 +47,7 @@ NaClValidationStatus ApplyDfaValidator_x86_32(
   callback_data.validate_chunk_func = ValidateChunkIA32;
   callback_data.did_rewrite = 0;
 
-  UNREFERENCED_PARAMETER(guest_addr);
+  NACL_UNUSED_PARAMETER(guest_addr);
 
   if (stubout_mode)
     return NaClValidationFailedNotImplemented;
@@ -108,7 +108,7 @@ static NaClValidationStatus ValidatorCopy_x86_32(
   /* TODO(jfb) Use a safe cast here. */
   NaClCPUFeaturesX86 *cpu_features = (NaClCPUFeaturesX86 *) f;
   struct CodeCopyCallbackData callback_data;
-  UNREFERENCED_PARAMETER(guest_addr);
+  NACL_UNUSED_PARAMETER(guest_addr);
 
   if (size & kBundleMask)
     return NaClValidationFailed;
@@ -277,7 +277,7 @@ static NaClValidationStatus ValidatorCodeReplacement_x86_32(
   /* TODO(jfb) Use a safe cast here. */
   NaClCPUFeaturesX86 *cpu_features = (NaClCPUFeaturesX86 *) f;
   struct CodeReplacementCallbackData callback_data;
-  UNREFERENCED_PARAMETER(guest_addr);
+  NACL_UNUSED_PARAMETER(guest_addr);
 
   if (size & kBundleMask)
     return NaClValidationFailed;
@@ -308,8 +308,8 @@ static Bool IsOnInstBoundaryCallback(const uint8_t *begin,
                                      uint32_t info,
                                      void *callback_data) {
   struct IsOnInstBoundaryCallbackData *data = callback_data;
-  UNREFERENCED_PARAMETER(info);
-  UNREFERENCED_PARAMETER(end);
+  NACL_UNUSED_PARAMETER(info);
+  NACL_UNUSED_PARAMETER(end);
 
   /*
    * For x86-32 superinstructions are at most 2 normal instructions,

--- a/src/trusted/validator_ragel/dfa_validate_64.c
+++ b/src/trusted/validator_ragel/dfa_validate_64.c
@@ -47,7 +47,7 @@ static NaClValidationStatus ApplyDfaValidator_x86_64(
   callback_data.validate_chunk_func = ValidateChunkAMD64;
   callback_data.did_rewrite = 0;
 
-  UNREFERENCED_PARAMETER(guest_addr);
+  NACL_UNUSED_PARAMETER(guest_addr);
 
   if (stubout_mode)
     return NaClValidationFailedNotImplemented;
@@ -109,7 +109,7 @@ static NaClValidationStatus ValidatorCodeCopy_x86_64(
   /* TODO(jfb) Use a safe cast here. */
   NaClCPUFeaturesX86 *cpu_features = (NaClCPUFeaturesX86 *) f;
   struct CodeCopyCallbackData callback_data;
-  UNREFERENCED_PARAMETER(guest_addr);
+  NACL_UNUSED_PARAMETER(guest_addr);
 
   if (size & kBundleMask)
     return NaClValidationFailed;
@@ -218,7 +218,7 @@ static NaClValidationStatus ValidatorCodeReplacement_x86_64(
     const NaClCPUFeatures *f) {
   /* TODO(jfb) Use a safe cast here. */
   NaClCPUFeaturesX86 *cpu_features = (NaClCPUFeaturesX86 *) f;
-  UNREFERENCED_PARAMETER(guest_addr);
+  NACL_UNUSED_PARAMETER(guest_addr);
 
   if (size & kBundleMask)
     return NaClValidationFailed;
@@ -241,7 +241,7 @@ static Bool IsOnInstBoundaryCallback(const uint8_t *begin,
                               uint32_t info,
                               void *callback_data) {
   struct IsOnInstBoundaryCallbackData *data = callback_data;
-  UNREFERENCED_PARAMETER(end);
+  NACL_UNUSED_PARAMETER(end);
 
   /*
    * Superinstructions are only reported when the final instruction

--- a/src/trusted/validator_ragel/dfa_validate_common.c
+++ b/src/trusted/validator_ragel/dfa_validate_common.c
@@ -26,10 +26,10 @@ static const uint8_t kStubOutMem[MAX_INSTRUCTION_LENGTH] = {
 
 Bool NaClDfaProcessValidationError(const uint8_t *begin, const uint8_t *end,
                                    uint32_t info, void *callback_data) {
-  UNREFERENCED_PARAMETER(begin);
-  UNREFERENCED_PARAMETER(end);
-  UNREFERENCED_PARAMETER(info);
-  UNREFERENCED_PARAMETER(callback_data);
+  NACL_UNUSED_PARAMETER(begin);
+  NACL_UNUSED_PARAMETER(end);
+  NACL_UNUSED_PARAMETER(info);
+  NACL_UNUSED_PARAMETER(callback_data);
 
   return FALSE;
 }
@@ -77,7 +77,7 @@ static Bool RewriteNonTemporal(uint8_t *ptr, uint8_t *end, uint32_t info) {
   }
 
 #if NACL_BUILD_SUBARCH == 32
-  UNREFERENCED_PARAMETER(info);
+  NACL_UNUSED_PARAMETER(info);
 
   if (size >= 2 && memcmp(ptr, "\x0f\xe7", 2) == 0) {
     /* movntq => movq */
@@ -192,9 +192,9 @@ static Bool BundleValidationCheckAfterRewrite(const uint8_t *begin,
                                               const uint8_t *end,
                                               uint32_t info,
                                               void *callback_data) {
-  UNREFERENCED_PARAMETER(begin);
-  UNREFERENCED_PARAMETER(end);
-  UNREFERENCED_PARAMETER(callback_data);
+  NACL_UNUSED_PARAMETER(begin);
+  NACL_UNUSED_PARAMETER(end);
+  NACL_UNUSED_PARAMETER(callback_data);
 
   return AllowErrorDuringBundleValidation(info);
 }

--- a/src/trusted/validator_ragel/dll_utils.c
+++ b/src/trusted/validator_ragel/dll_utils.c
@@ -22,7 +22,7 @@
 
 void NaClLog(int detail_level, char const *fmt, ...) {
   va_list ap;
-  UNREFERENCED_PARAMETER(detail_level);
+  NACL_UNUSED_PARAMETER(detail_level);
   va_start(ap, fmt);
   vprintf(fmt, ap);
   va_end(ap);

--- a/src/trusted/validator_ragel/docs/validator_internals.html
+++ b/src/trusted/validator_ragel/docs/validator_internals.html
@@ -177,7 +177,7 @@ It's “more interesting” not because it's complex or non-obvious. The interes
 &nbsp;&nbsp;&nbsp;&nbsp;<code>Rel32Operand(current_position&nbsp;+&nbsp;1,&nbsp;codeblock,&nbsp;jump_dests,&nbsp;size,</code><br />
 &nbsp;&nbsp;&nbsp;&nbsp;<code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&amp;instruction_info_collected);</code></br />
 &nbsp;&nbsp;<code>}</code><hr />
-<code>static&nbsp;FORCEINLINE&nbsp;int&nbsp;MarkJumpTarget(size_t&nbsp;jump_dest,</code></br>
+<code>static&nbsp;NACL_FORCEINLINE&nbsp;int&nbsp;MarkJumpTarget(size_t&nbsp;jump_dest,</code></br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bitmap_word&nbsp;*jump_dests,</code></br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;size_t&nbsp;size)&nbsp;{</code></br>
 &nbsp;&nbsp;<code>if&nbsp;((jump_dest&nbsp;&amp;&nbsp;kBundleMask)&nbsp;==&nbsp;0)&nbsp;{</code></br>
@@ -189,7 +189,7 @@ It's “more interesting” not because it's complex or non-obvious. The interes
 &nbsp;&nbsp;<code>BitmapSetBit(jump_dests,&nbsp;jump_dest);</code></br>
 &nbsp;&nbsp;<code>return&nbsp;TRUE;</code></br>
 <code>}</code></br>
-<code>static&nbsp;FORCEINLINE&nbsp;void&nbsp;Rel8Operand(const&nbsp;uint8_t&nbsp;*rip,</code><br />
+<code>static&nbsp;NACL_FORCEINLINE&nbsp;void&nbsp;Rel8Operand(const&nbsp;uint8_t&nbsp;*rip,</code><br />
 <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;const&nbsp;uint8_t&nbsp;codeblock[],</code><br />
 <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bitmap_word&nbsp;*jump_dests,</code><br />
 <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;size_t&nbsp;jumpdests_size,</code><br />
@@ -201,7 +201,7 @@ It's “more interesting” not because it's complex or non-obvious. The interes
 &nbsp;&nbsp;<code>else</code><br />
 &nbsp;&nbsp;&nbsp;&nbsp;<code>*instruction_info_collected&nbsp;|=&nbsp;RELATIVE_8BIT&nbsp;|&nbsp;DIRECT_JUMP_OUT_OF_RANGE;</code><br />
 <code>}</code><br /><br /><br />
-<code>static&nbsp;FORCEINLINE&nbsp;void&nbsp;Rel32Operand(const&nbsp;uint8_t&nbsp;*rip,</code><br />
+<code>static&nbsp;NACL_FORCEINLINE&nbsp;void&nbsp;Rel32Operand(const&nbsp;uint8_t&nbsp;*rip,</code><br />
 <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;const&nbsp;uint8_t&nbsp;codeblock[],</code><br />
 <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bitmap_word&nbsp;*jump_dests,</code><br />
 <code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;size_t&nbsp;jumpdests_size,</code><br />

--- a/src/trusted/validator_ragel/gen/validator_x86_64.c
+++ b/src/trusted/validator_ragel/gen/validator_x86_64.c
@@ -1151,7 +1151,7 @@ static INLINE void CheckMemoryAccess(ptrdiff_t instruction_begin,
   }
 }
 
-static FORCEINLINE uint32_t CheckValidityOfRegularInstruction(
+static NACL_FORCEINLINE uint32_t CheckValidityOfRegularInstruction(
     enum OperandName restricted_register) {
   /*
    * Restricted %rsp or %rbp must be %rsp or %rbp must be restored from

--- a/src/trusted/validator_ragel/unreviewed/decoder_test.cc
+++ b/src/trusted/validator_ragel/unreviewed/decoder_test.cc
@@ -35,7 +35,7 @@ const int INSN_WIDTH = 15; /* Counterpart of '--insn-width' objdump option. */
 void NaClLog(int detail_level, char const  *fmt, ...) {
   va_list ap;
 
-  UNREFERENCED_PARAMETER(detail_level);
+  NACL_UNUSED_PARAMETER(detail_level);
   va_start(ap, fmt);
   vfprintf(stderr, fmt, ap);
   exit(1);

--- a/src/trusted/validator_ragel/validator_benchmark.cc
+++ b/src/trusted/validator_ragel/validator_benchmark.cc
@@ -20,9 +20,9 @@
 Bool ProcessError(
     const uint8_t *begin, const uint8_t *end,
     uint32_t validation_info, void *user_data_ptr) {
-  UNREFERENCED_PARAMETER(begin);
-  UNREFERENCED_PARAMETER(end);
-  UNREFERENCED_PARAMETER(user_data_ptr);
+  NACL_UNUSED_PARAMETER(begin);
+  NACL_UNUSED_PARAMETER(end);
+  NACL_UNUSED_PARAMETER(user_data_ptr);
   if (validation_info & (VALIDATION_ERRORS_MASK | BAD_JUMP_TARGET))
     return FALSE;
   else

--- a/src/trusted/validator_ragel/validator_internal.h
+++ b/src/trusted/validator_ragel/validator_internal.h
@@ -154,7 +154,7 @@ extern const NaClCPUFeaturesX86 kValidatorCPUIDFeatures;
  *
  * Returns TRUE iff the jump passes the early validity check.
  */
-static FORCEINLINE int MarkJumpTarget(size_t jump_dest,
+static NACL_FORCEINLINE int MarkJumpTarget(size_t jump_dest,
                                       bitmap_word *jump_dests,
                                       size_t size) {
   if ((jump_dest & kBundleMask) == 0) {
@@ -170,7 +170,7 @@ static FORCEINLINE int MarkJumpTarget(size_t jump_dest,
 /*
  * Mark the given address as valid jump target address.
  */
-static FORCEINLINE void MarkValidJumpTarget(size_t address,
+static NACL_FORCEINLINE void MarkValidJumpTarget(size_t address,
                                             bitmap_word *valid_targets) {
   BitmapSetBit(valid_targets, address);
 }
@@ -178,7 +178,7 @@ static FORCEINLINE void MarkValidJumpTarget(size_t address,
 /*
  * Mark the given address as invalid jump target address (that is: unmark it).
  */
-static FORCEINLINE void UnmarkValidJumpTarget(size_t address,
+static NACL_FORCEINLINE void UnmarkValidJumpTarget(size_t address,
                                               bitmap_word *valid_targets) {
   BitmapClearBit(valid_targets, address);
 }
@@ -187,7 +187,7 @@ static FORCEINLINE void UnmarkValidJumpTarget(size_t address,
  * Mark the given addresses as invalid jump target addresses (that is: unmark
  * them).
  */
-static FORCEINLINE void UnmarkValidJumpTargets(size_t address,
+static NACL_FORCEINLINE void UnmarkValidJumpTargets(size_t address,
                                                size_t bytes,
                                                bitmap_word *valid_targets) {
   BitmapClearBits(valid_targets, address, bytes);
@@ -232,7 +232,7 @@ static INLINE Bool ProcessInvalidJumpTargets(
  * instruction here and x86 encoding guarantees rel8 field is the last one
  * in a current instruction.
  */
-static FORCEINLINE void Rel8Operand(const uint8_t *rip,
+static NACL_FORCEINLINE void Rel8Operand(const uint8_t *rip,
                                     const uint8_t codeblock[],
                                     bitmap_word *jump_dests,
                                     size_t jumpdests_size,
@@ -251,7 +251,7 @@ static FORCEINLINE void Rel8Operand(const uint8_t *rip,
  * instruction here and x86 encoding guarantees rel32 field is the last one
  * in a current instruction.
  */
-static FORCEINLINE void Rel32Operand(const uint8_t *rip,
+static NACL_FORCEINLINE void Rel32Operand(const uint8_t *rip,
                                      const uint8_t codeblock[],
                                      bitmap_word *jump_dests,
                                      size_t jumpdests_size,

--- a/src/trusted/validator_ragel/validator_x86_64.rl
+++ b/src/trusted/validator_ragel/validator_x86_64.rl
@@ -786,7 +786,7 @@ static INLINE void CheckMemoryAccess(ptrdiff_t instruction_begin,
   }
 }
 
-static FORCEINLINE uint32_t CheckValidityOfRegularInstruction(
+static NACL_FORCEINLINE uint32_t CheckValidityOfRegularInstruction(
     enum OperandName restricted_register) {
   /*
    * Restricted %rsp or %rbp must be %rsp or %rbp must be restored from

--- a/tests/common/register_set.c
+++ b/tests/common/register_set.c
@@ -163,7 +163,7 @@ void RegsApplySandboxConstraints(struct NaClSignalContext *regs) {
   regs->stack_ptr = r15 + (uint32_t) regs->stack_ptr;
   regs->rbp = r15 + (uint32_t) regs->rbp;
 #else
-  UNREFERENCED_PARAMETER(regs);
+  NACL_UNUSED_PARAMETER(regs);
 #endif
 }
 #endif
@@ -198,7 +198,7 @@ static void RegsNormalizeFlags(struct NaClSignalContext *regs) {
   regs->cpsr &= REGS_ARM_USER_CPSR_FLAGS_MASK;
 #elif NACL_ARCH(NACL_BUILD_ARCH) == NACL_mips
   /* No flags field on MIPS. */
-  UNREFERENCED_PARAMETER(regs);
+  NACL_UNUSED_PARAMETER(regs);
 #endif
 }
 

--- a/tests/faulted_thread_queue/faultqueue_test_host.c
+++ b/tests/faulted_thread_queue/faultqueue_test_host.c
@@ -174,7 +174,7 @@ void TestSingleStepping(struct NaClAppThread *natp) {
 
 /* ARM/MIPS do not have hardware single-stepping, so nothing to do here. */
 void TestSingleStepping(struct NaClAppThread *natp) {
-  UNREFERENCED_PARAMETER(natp);
+  NACL_UNUSED_PARAMETER(natp);
 }
 
 #else

--- a/tests/lock_manager/nacl_file_lock_test.c
+++ b/tests/lock_manager/nacl_file_lock_test.c
@@ -113,8 +113,8 @@ static void NaClFileLockTestSetFileIdentityData(
                  int desc),
     struct NaClFileLockEntry *entry,
     int desc) {
-  UNREFERENCED_PARAMETER(vself);
-  UNREFERENCED_PARAMETER(orig);
+  NACL_UNUSED_PARAMETER(vself);
+  NACL_UNUSED_PARAMETER(orig);
   entry->file_dev = 0;
   entry->file_ino = desc;
 }
@@ -126,7 +126,7 @@ static int NaClFileLockTestTakeFileLock(struct NaClFileLockTestInterface *vself,
   struct NaClFileLockTestImpl *self = (struct NaClFileLockTestImpl *) vself;
   int success = 0;
 
-  UNREFERENCED_PARAMETER(orig);
+  NACL_UNUSED_PARAMETER(orig);
   pthread_mutex_lock(&self->mu);
   for (;;) {
     if (self->num_files <= (size_t) desc) {
@@ -154,7 +154,7 @@ static int NaClFileLockTestDropFileLock(struct NaClFileLockTestInterface *vself,
   struct NaClFileLockTestImpl *self = (struct NaClFileLockTestImpl *) vself;
   int success = 0;
 
-  UNREFERENCED_PARAMETER(orig);
+  NACL_UNUSED_PARAMETER(orig);
   pthread_mutex_lock(&self->mu);
   if (self->num_files <= (size_t) desc) {
     printf("Bad descriptor %d, num_files = %d\n",
@@ -290,7 +290,7 @@ static int NaClFileLockTestRealFileTakeFileLock(
       (struct NaClFileLockTestRealFileImpl *) vself;
   int real_desc = NaClFileLockTestRealFileGetDesc(self, desc);
 
-  UNREFERENCED_PARAMETER(thread_number);
+  NACL_UNUSED_PARAMETER(thread_number);
   if (-1 == real_desc) {
     printf("RealFileTakeFileLock: Bad descriptor %d\n", desc);
     return 0;
@@ -311,7 +311,7 @@ static int NaClFileLockTestRealFileDropFileLock(
       (struct NaClFileLockTestRealFileImpl *) vself;
   int real_desc = NaClFileLockTestRealFileGetDesc(self, desc);
 
-  UNREFERENCED_PARAMETER(thread_number);
+  NACL_UNUSED_PARAMETER(thread_number);
   if (-1 == real_desc) {
     printf("RealFileDropFileLock: Bad descriptor %d\n", desc);
     return 0;

--- a/tests/lock_manager/nacl_test_util_repl.c
+++ b/tests/lock_manager/nacl_test_util_repl.c
@@ -531,7 +531,7 @@ struct NaClSexpNode *SetFilesImpl(struct NaClSexpCons *cons,
 
 struct NaClSexpNode *QuoteImpl(struct NaClSexpCons *cons,
                                struct WorkState *ws) {
-  UNREFERENCED_PARAMETER(ws);
+  NACL_UNUSED_PARAMETER(ws);
   if (NaClSexpListLength(cons) != 2) {
     error_cons(ws, "quote takes a single argument", cons);
     return NULL;

--- a/tests/minnacl/minimal_test_host.c
+++ b/tests/minnacl/minimal_test_host.c
@@ -19,7 +19,7 @@
 #include "native_client/tests/minnacl/minimal_test_syscalls.h"
 
 static int32_t MySyscallInvoke(struct NaClAppThread *natp) {
-  UNREFERENCED_PARAMETER(natp);
+  NACL_UNUSED_PARAMETER(natp);
 
   printf("Inside custom test 'invoke' syscall\n");
   fflush(stdout);
@@ -28,7 +28,7 @@ static int32_t MySyscallInvoke(struct NaClAppThread *natp) {
 }
 
 static int32_t MySyscallExit(struct NaClAppThread *natp) {
-  UNREFERENCED_PARAMETER(natp);
+  NACL_UNUSED_PARAMETER(natp);
 
   printf("Inside custom test 'exit' syscall\n");
   fflush(stdout);

--- a/tests/mmap/mmap_prot_test.c
+++ b/tests/mmap/mmap_prot_test.c
@@ -321,7 +321,7 @@ int test_prot_mapping(int fd, size_t map_size, void *test_spec) {
 
 int test_prot_ronly_rw(int fd, size_t map_size, void *test_spec) {
   char *addr;
-  UNREFERENCED_PARAMETER(test_spec);
+  NACL_UNUSED_PARAMETER(test_spec);
 
   addr = (char *) mmap(NULL, map_size, PROT_READ, MAP_SHARED, fd, 0);
   CHECK(addr != MAP_FAILED);

--- a/tests/mmap_prot_exec/mmap_prot_exec.c
+++ b/tests/mmap_prot_exec/mmap_prot_exec.c
@@ -20,7 +20,7 @@
 /* Get macros for NACL_ARCH(NACL_BUILD_ARCH) == NACL_x86 etc. */
 #include "native_client/src/include/nacl_base.h"
 
-/* Get UNREFERENCED_PARAMETER definition. */
+/* Get NACL_UNUSED_PARAMETER definition. */
 #include "native_client/src/include/nacl_compiler_annotations.h"
 
 /* Get macro for NACL_ARRAY_SIZE. */
@@ -254,7 +254,7 @@ int map_shared_test(int d, size_t map_size, void *test_specifics) {
   char *v1ptr;
   char *v2ptr;
 
-  UNREFERENCED_PARAMETER(test_specifics);
+  NACL_UNUSED_PARAMETER(test_specifics);
 
   if (MAP_FAILED ==
       (view1 = mmap(NULL,
@@ -444,7 +444,7 @@ int map_private_test_ro(int d, size_t file_size, void *test_specifics) {
 int map_rw_ronly_file_test(int d, size_t file_size, void *test_specifics) {
   void *view;
 
-  UNREFERENCED_PARAMETER(test_specifics);
+  NACL_UNUSED_PARAMETER(test_specifics);
   errno = 0;
   view = mmap(NULL, file_size, PROT_READ | PROT_WRITE, MAP_SHARED, d,
               /* offset */ 0);

--- a/tests/performance/perf_test_threads.cc
+++ b/tests/performance/perf_test_threads.cc
@@ -80,7 +80,7 @@ class TestThreadCreateAndJoin : public PerfTest {
 
  private:
   static void *EmptyThread(void *thread_arg) {
-    UNREFERENCED_PARAMETER(thread_arg);
+    NACL_UNUSED_PARAMETER(thread_arg);
     return NULL;
   }
 };

--- a/tests/sel_main_chrome/sel_main_chrome_test.cc
+++ b/tests/sel_main_chrome/sel_main_chrome_test.cc
@@ -63,15 +63,15 @@ struct TestValidationQuery {
 };
 
 static void *TestCreateQuery(void *handle) {
-  UNREFERENCED_PARAMETER(handle);
+  NACL_UNUSED_PARAMETER(handle);
   return static_cast<void *>(new TestValidationQuery());
 }
 
 static void TestAddData(void *query, const unsigned char *data,
                         size_t length) {
-  UNREFERENCED_PARAMETER(query);
-  UNREFERENCED_PARAMETER(data);
-  UNREFERENCED_PARAMETER(length);
+  NACL_UNUSED_PARAMETER(query);
+  NACL_UNUSED_PARAMETER(data);
+  NACL_UNUSED_PARAMETER(length);
 }
 
 static int TestQueryKnownToValidate(void *query) {
@@ -89,20 +89,20 @@ static void TestDestroyQuery(void *query) {
 }
 
 static int TestCachingIsInexpensive(const struct NaClValidationMetadata *m) {
-  UNREFERENCED_PARAMETER(m);
+  NACL_UNUSED_PARAMETER(m);
   return 1;
 }
 
 void ExampleDescDestroy(void *handle) {
-  UNREFERENCED_PARAMETER(handle);
+  NACL_UNUSED_PARAMETER(handle);
 }
 
 ssize_t ExampleDescSendMsg(void *handle,
                            const struct NaClImcTypedMsgHdr *msg,
                            int flags) {
-  UNREFERENCED_PARAMETER(handle);
-  UNREFERENCED_PARAMETER(msg);
-  UNREFERENCED_PARAMETER(flags);
+  NACL_UNUSED_PARAMETER(handle);
+  NACL_UNUSED_PARAMETER(msg);
+  NACL_UNUSED_PARAMETER(flags);
 
   NaClLog(LOG_FATAL, "ExampleDescSendMsg: Not implemented\n");
   return 0;
@@ -111,9 +111,9 @@ ssize_t ExampleDescSendMsg(void *handle,
 ssize_t ExampleDescRecvMsg(void *handle,
                            struct NaClImcTypedMsgHdr *msg,
                            int flags) {
-  UNREFERENCED_PARAMETER(handle);
-  UNREFERENCED_PARAMETER(msg);
-  UNREFERENCED_PARAMETER(flags);
+  NACL_UNUSED_PARAMETER(handle);
+  NACL_UNUSED_PARAMETER(msg);
+  NACL_UNUSED_PARAMETER(flags);
 
   NaClLog(LOG_FATAL, "ExampleDescRecvMsg: Not implemented\n");
   return 0;

--- a/tests/signal_handler_single_step/step_test_host.c
+++ b/tests/signal_handler_single_step/step_test_host.c
@@ -132,13 +132,13 @@ static void TrapSignalHandler(int signal,
 }
 
 static void ThreadCreateHook(struct NaClAppThread *natp) {
-  UNREFERENCED_PARAMETER(natp);
+  NACL_UNUSED_PARAMETER(natp);
 
   SetTrapFlag();
 }
 
 static void ThreadExitHook(struct NaClAppThread *natp) {
-  UNREFERENCED_PARAMETER(natp);
+  NACL_UNUSED_PARAMETER(natp);
 }
 
 static void ProcessExitHook(void) {

--- a/tests/thread_capture/arch/mips/thread_capture_test_injection.c
+++ b/tests/thread_capture/arch/mips/thread_capture_test_injection.c
@@ -13,7 +13,7 @@
 #include "native_client/src/trusted/service_runtime/nacl_tls.h"
 
 static int32_t TestSyscall(struct NaClAppThread *natp) {
-  UNREFERENCED_PARAMETER(natp);
+  NACL_UNUSED_PARAMETER(natp);
 
   g_nacl_syscall_thread_capture_fault_addr =
       (uintptr_t) &NaClSyscallThreadCaptureFault;

--- a/tests/thread_capture/arch/x86_64/thread_capture_test_injection.c
+++ b/tests/thread_capture/arch/x86_64/thread_capture_test_injection.c
@@ -14,7 +14,7 @@
 #include "native_client/src/trusted/service_runtime/nacl_tls.h"
 
 static int32_t TestSyscall(struct NaClAppThread *natp) {
-  UNREFERENCED_PARAMETER(natp);
+  NACL_UNUSED_PARAMETER(natp);
 
   g_nacl_syscall_thread_capture_fault_addr =
       (uintptr_t) &NaClSyscallThreadCaptureFault;

--- a/tests/thread_capture/nacl_thread_capture_test_injection_test.c
+++ b/tests/thread_capture/nacl_thread_capture_test_injection_test.c
@@ -31,7 +31,7 @@ void NaClSignalHandler(int signum, siginfo_t *info, void *other) {
   uintptr_t faulting_pc;
   ucontext_t *ucp;
 
-  UNREFERENCED_PARAMETER(info);
+  NACL_UNUSED_PARAMETER(info);
   ucp = (ucontext_t *) other;
 #if NACL_LINUX
 # if NACL_ARCH(NACL_BUILD_ARCH) == NACL_x86

--- a/tests/toolchain/eh_throw_tests.cc
+++ b/tests/toolchain/eh_throw_tests.cc
@@ -281,7 +281,7 @@ class DtorThrowCatch {
 __attribute__((noinline))
 void nested_throw_catch() {
   DtorThrowCatch obj;
-  UNREFERENCED_PARAMETER(obj);
+  NACL_UNUSED_PARAMETER(obj);
   throw MyException(50);
 }
 

--- a/tests/toolchain/eh_uncaught_exception.cc
+++ b/tests/toolchain/eh_uncaught_exception.cc
@@ -38,7 +38,7 @@ class ObjWithDtor {
 int main() {
   std::set_terminate(terminate_handler);
   ObjWithDtor obj;
-  UNREFERENCED_PARAMETER(obj);
+  NACL_UNUSED_PARAMETER(obj);
   throw 1;
   return 1;
 }

--- a/tests/trusted_crash/crash_in_syscall/test_host.c
+++ b/tests/trusted_crash/crash_in_syscall/test_host.c
@@ -261,7 +261,7 @@ static void RegisterHandlers(void) {
 int32_t JumpToZeroCrashSyscall(struct NaClAppThread *natp) {
   void (*null_func_ptr)(void) = NULL;
 
-  UNREFERENCED_PARAMETER(natp);
+  NACL_UNUSED_PARAMETER(natp);
 
   null_func_ptr();
 

--- a/tests/trusted_crash/osx_crash_filter/crash_filter_test.c
+++ b/tests/trusted_crash/osx_crash_filter/crash_filter_test.c
@@ -43,10 +43,10 @@ kern_return_t catch_exception_raise(mach_port_t port,
                                     mach_msg_type_number_t code_count) {
   int is_untrusted;
 
-  UNREFERENCED_PARAMETER(port);
-  UNREFERENCED_PARAMETER(exception_type);
-  UNREFERENCED_PARAMETER(exception_code);
-  UNREFERENCED_PARAMETER(code_count);
+  NACL_UNUSED_PARAMETER(port);
+  NACL_UNUSED_PARAMETER(exception_type);
+  NACL_UNUSED_PARAMETER(exception_code);
+  NACL_UNUSED_PARAMETER(code_count);
 
   CHECK(task == mach_task_self());
   fprintf(stderr, "Received a crash, as expected\n");

--- a/tests/trusted_crash/osx_crash_forwarding/mach_crash_forwarding_test.c
+++ b/tests/trusted_crash/osx_crash_forwarding/mach_crash_forwarding_test.c
@@ -43,11 +43,11 @@ kern_return_t catch_exception_raise(mach_port_t port,
                                     exception_type_t exception_type,
                                     exception_data_t exception_code,
                                     mach_msg_type_number_t code_count) {
-  UNREFERENCED_PARAMETER(port);
-  UNREFERENCED_PARAMETER(crashing_thread);
-  UNREFERENCED_PARAMETER(exception_type);
-  UNREFERENCED_PARAMETER(exception_code);
-  UNREFERENCED_PARAMETER(code_count);
+  NACL_UNUSED_PARAMETER(port);
+  NACL_UNUSED_PARAMETER(crashing_thread);
+  NACL_UNUSED_PARAMETER(exception_type);
+  NACL_UNUSED_PARAMETER(exception_code);
+  NACL_UNUSED_PARAMETER(code_count);
 
   CHECK(task == mach_task_self());
   CHECK(g_expect_crash);

--- a/tests/unittests/shared/imc/double_nacl_close_test.c
+++ b/tests/unittests/shared/imc/double_nacl_close_test.c
@@ -24,8 +24,8 @@ int main(int argc, char* argv[]) {
   int result;
   NaClHandle pair[2];
 
-  UNREFERENCED_PARAMETER(argc);
-  UNREFERENCED_PARAMETER(argv);
+  NACL_UNUSED_PARAMETER(argc);
+  NACL_UNUSED_PARAMETER(argv);
 
   if (0 != NaClSocketPair(pair)) {
     failWithErrno("SocketPair");

--- a/tests/unittests/shared/imc/nacl_close_test.c
+++ b/tests/unittests/shared/imc/nacl_close_test.c
@@ -22,8 +22,8 @@ static void failWithErrno(const char* message) {
 int main(int argc, char* argv[]) {
   NaClHandle pair[2];
 
-  UNREFERENCED_PARAMETER(argc);
-  UNREFERENCED_PARAMETER(argv);
+  NACL_UNUSED_PARAMETER(argc);
+  NACL_UNUSED_PARAMETER(argv);
 
   if (0 != NaClSocketPair(pair)) {
     failWithErrno("SocketPair");

--- a/tests/unittests/shared/imc/nacl_create_memory_object_test.c
+++ b/tests/unittests/shared/imc/nacl_create_memory_object_test.c
@@ -24,8 +24,8 @@ static void failWithErrno(const char* message) {
 int main(int argc, char* argv[]) {
   NaClHandle handle;
 
-  UNREFERENCED_PARAMETER(argc);
-  UNREFERENCED_PARAMETER(argv);
+  NACL_UNUSED_PARAMETER(argc);
+  NACL_UNUSED_PARAMETER(argv);
 
   /* Check not executable shared memory. */
   handle = NaClCreateMemoryObject(MEMORY_SIZE, 0);

--- a/tests/unittests/shared/platform/nacl_thread_create_joinable_test.c
+++ b/tests/unittests/shared/platform/nacl_thread_create_joinable_test.c
@@ -37,8 +37,8 @@ int main(int argc, char* argv[]) {
   int num = TEST_NUM;
   struct NaClThread thr;
 
-  UNREFERENCED_PARAMETER(argc);
-  UNREFERENCED_PARAMETER(argv);
+  NACL_UNUSED_PARAMETER(argc);
+  NACL_UNUSED_PARAMETER(argv);
 
   if (!NaClThreadCreateJoinable(&thr, myThread, &num, 128*1024)) {
     failWithErrno("NaClThreadCreateJoinable");

--- a/tests/unittests/trusted/service_runtime/nacl_memory_test.c
+++ b/tests/unittests/trusted/service_runtime/nacl_memory_test.c
@@ -28,8 +28,8 @@ void run_check(void) {
 
 int main(int argc, char* argv[]) {
   int i;
-  UNREFERENCED_PARAMETER(argc);
-  UNREFERENCED_PARAMETER(argv);
+  NACL_UNUSED_PARAMETER(argc);
+  NACL_UNUSED_PARAMETER(argv);
 
   NaClPlatformInit();
 


### PR DESCRIPTION
Some other errors and warnings I ran into when attempting a MinGW build. Fix headers, compiler attributes, etc. Notably not fixed: the `THREAD` macro for the thread-local attribute.