### PR TITLE
Clean up GDB tests

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -150,6 +150,8 @@ ACCEPTABLE_ARGUMENTS = set([
     # When building with MSan, this can be set to values 0 (fastest, least
     # useful reports) through 2 (slowest, most useful reports). Default is 1.
     'msan_track_origins',
+    # Path to GDB to use on NaCl targets
+    'nacl_gdb',
     # colon-separated list of linker flags, e.g. "-lfoo:-Wl,-u,bar".
     'nacl_linkflags',
     # prefix to add in-front of perf tracking trace labels.

--- a/site_scons/site_tools/naclsdk.py
+++ b/site_scons/site_tools/naclsdk.py
@@ -756,7 +756,8 @@ def generate(env):
     _SetEnvForNativeSdk(env, root)
 
   # Daemon: don't depend on a second NaCl toolchain!
-  if (env.Bit('bitcode') or env.Bit('nacl_clang')) and env.Bit('build_x86') and not env.Bit('no_gdb_tests'):
+  if (env.Bit('bitcode') or env.Bit('nacl_clang')) and env.Bit('build_x86') and \
+     not env.Bit('no_gdb_tests') and 'nacl_gdb' not in SCons.Script.ARGUMENTS:
     # Get GDB from the nacl-gcc glibc toolchain even when using PNaCl.
     # TODO(mseaborn): We really want the nacl-gdb binary to be in a
     # separate tarball from the nacl-gcc toolchain, then this step

--- a/tests/gdb/nacl.scons
+++ b/tests/gdb/nacl.scons
@@ -5,6 +5,8 @@
 
 import os
 
+import SCons
+
 Import('env')
 
 if 'TRUSTED_ENV' not in env:
@@ -17,7 +19,9 @@ if env.UnderWindowsCoverage():
 if env.Bit('build_arm'):
   Return()
 
-if env.Bit('build_arm') or env.Bit('build_mips32'):
+if 'nacl_gdb' in SCons.Script.ARGUMENTS:
+  env.Replace(GDB=SCons.Script.ARGUMENTS['nacl_gdb'])
+elif env.Bit('build_arm') or env.Bit('build_mips32'):
   if env.UsingEmulator():
     # nacl-gdb is built with ARM support but not MIPS support.
     if env.Bit('build_mips32'):

--- a/tests/gdb/nacl.scons
+++ b/tests/gdb/nacl.scons
@@ -117,34 +117,29 @@ def AddGdbTest(name, is_broken=False, is_thread_test=False):
                                     (env.Bit('nacl_glibc') and
                                      env.Bit('build_arm'))))
 
+# Platforms where single stepping is not implemented. This is needed not just
+# for stepi itself, but also for `continue` - without the single step, the
+# breakpoint is erased upon continuing. Also it's broken if a thread
+# is created after continuing (https://github.com/DaemonEngine/native_client/issues/57).
+no_step = env.Bit('build_arm') or env.Bit('build_mips32')
 
 AddGdbTest('complete')
 AddGdbTest('detach')
-AddGdbTest('disconnect')
 
-using_clang = env.Bit('bitcode') or env.Bit('nacl_clang')
+# This *could* work on ARM but the final breakpoint is just placed slightly off.
+AddGdbTest('disconnect', is_broken=env.Bit('build_arm'))
+
+using_clang = env.Bit('bitcode') or (env.Bit('nacl_clang') and not env.Bit('saigo'))
 
 # https://code.google.com/p/nativeclient/issues/detail?id=4059
 AddGdbTest('invalid_memory',
            is_broken = (using_clang and not env.UsingEmulator()))
 AddGdbTest('kill')
-# TODO(crbug.com/1101347): This fails on ARM bots.
-AddGdbTest('remote_get', is_broken=env.Bit('build_arm') and not env.UsingEmulator())
+AddGdbTest('remote_get')
 
-# Single-stepping does work reliably with ARM and MIPS in qemu due to the code
-# cache not being flushable.
-AddGdbTest('stepi_after_break', is_broken=env.UsingEmulator())
+AddGdbTest('stepi_after_break', is_broken=no_step)
 
-# This fails on ARM+PNaCl. The set_global_var function appears to be
-# getting the wrong argument value (68K vs 1), so the value of
-# global_var doesn't match the expected value.
-# TODO(mseaborn): Investigate and enable this test.
-# http://code.google.com/p/nativeclient/issues/detail?id=3252
-# This test also fails with arm-nacl-clang:
-# https://code.google.com/p/nativeclient/issues/detail?id=4059
-AddGdbTest('print_symbol',
-           is_broken=((using_clang and env.Bit('build_arm'))
-                      or env.UsingEmulator()))
+AddGdbTest('print_symbol', is_broken=no_step)
 
 # This fails on ARM+PNaCl because it gets an
 # unexpected value for a function argument from
@@ -154,35 +149,19 @@ AddGdbTest('print_symbol',
 AddGdbTest('stack_trace',
            is_broken=using_clang and env.Bit('build_arm'))
 
-# This fails on ARM+nacl-clang
-# https://code.google.com/p/nativeclient/issues/detail?id=4059
-AddGdbTest('step_from_func_start',
-           is_broken=(env.UsingEmulator() or
-                      (env.Bit('nacl_clang') and env.Bit('build_arm'))))
+AddGdbTest('step_from_func_start', is_broken=no_step)
 
 # This fails on MIPS, since GDB for MIPS executes inferior calls on stack
 # (call dummy location in MIPS GDB is set as ON_STACK method). Since the stack
 # is not executable under NaCl, this makes inferior call impossible to execute.
 AddGdbTest('call_from_gdb', is_broken=env.Bit('build_mips32'))
 
-# This fails on ARM/MIPS+PNaCl because it is reading
-# local_var before it has been initialised.
-# TODO(mseaborn): Investigate and enable this test.
-# http://code.google.com/p/nativeclient/issues/detail?id=3252
-# This test also fails with arm-nacl-clang:
-# https://code.google.com/p/nativeclient/issues/detail?id=4059
-AddGdbTest('change_variable',
-           is_broken=((using_clang and env.Bit('build_arm')) or
-                      env.Bit('build_mips32') or
-                      env.UsingEmulator()))
+AddGdbTest('change_variable', is_broken=no_step)
 
 if not env.Bit('nacl_static_link'):
   AddGdbTest('execute_nacl_manifest_twice')
 
-# This test hangs under qemu-arm because thread suspension doesn't
-# work on qemu-arm.
-AddGdbTest('break_continue_thread', is_thread_test=True,
-           is_broken=env.UsingEmulator())
+AddGdbTest('break_continue_thread', is_thread_test=True, is_broken=no_step)
 
 AddGdbTest('syscall_thread', is_thread_test=True)
 

--- a/tests/gdb/nacl.scons
+++ b/tests/gdb/nacl.scons
@@ -15,10 +15,6 @@ if 'TRUSTED_ENV' not in env:
 if env.UnderWindowsCoverage():
   Return()
 
-# ARM bots don't have gdb to run these tests
-if env.Bit('build_arm'):
-  Return()
-
 if 'nacl_gdb' in SCons.Script.ARGUMENTS:
   env.Replace(GDB=SCons.Script.ARGUMENTS['nacl_gdb'])
 elif env.Bit('build_arm') or env.Bit('build_mips32'):

--- a/tests/gdb/stack_trace.py
+++ b/tests/gdb/stack_trace.py
@@ -19,11 +19,8 @@ class StackTraceTest(gdb_test.GdbTest):
     result = self.gdb.Command('-stack-list-arguments 1 0 1')
     self.assertEqual(result[b'stack-args'][0][b'frame'][b'args'][0][b'value'],
                       b'2')
-    # This stopped working somewhere between llvm commits
-    # ecea8371ff03c15fb3dc27ee4108b98335fd2d63 and
-    # 1d5d18924d185a4267462479307f1ff9911cb112
-    #self.assertEqual(result[b'stack-args'][1][b'frame'][b'args'][0][b'value'],
-    #                  b'1')
+    self.assertEqual(result[b'stack-args'][1][b'frame'][b'args'][0][b'value'],
+                     b'1')
     self.gdb.Command('return')
     self.gdb.ResumeAndExpectStop('finish', 'function-finished')
     self.assertEqual(self.gdb.Eval('global_var'), b'1')


### PR DESCRIPTION
I added the `nacl_gdb` path option and used this to test our own GDB builds for Linux amd64, Linux arm and Windows 64. Several don't work for ARM so I have disabled them accordingly. On the other platforms the tests pass.